### PR TITLE
fix link issue when use cmake generate xcode project and run http_client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
                         NOT "$ENV{TRAVIS}" MATCHES "^true$" AND
                         NOT "$ENV{EXTRA_CFLAGS}" MATCHES "-fsanitize")
         SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -fsanitize=address")
+        SET(LIBS ${LIBS} -fsanitize=address)
     ENDIF()
     # Uncomment to enable cleartext protocol mode (no crypto):
     #SET (MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -DLSQUIC_ENABLE_HANDSHAKE_DISABLE=1")


### PR DESCRIPTION
if not add this link flag, it will report errors as below:


ld: warning: directory not found for option '-L/usr/local/lib/Debug'
Undefined symbols for architecture x86_64:
  "___asan_alloca_poison", referenced from:
      _send_headers_ietf in liblsquic.a(lsquic_stream.o)
      _qeh_write_headers in liblsquic.a(lsquic_qenc_hdl.o)
      _lsquic_qhkdf_expand in liblsquic.a(lsquic_hkdf.o)
  "___asan_allocas_unpoison", referenced from:
      _send_headers_ietf in liblsquic.a(lsquic_stream.o)
      _qeh_write_headers in liblsquic.a(lsquic_qenc_hdl.o)
      _lsquic_qhkdf_expand in liblsquic.a(lsquic_hkdf.o)
  "___asan_handle_no_return", referenced from:
      _main in echo_client.o
      _read_stdin in echo_client.o
      _prog_sport_cant_send in prog.o
      _send_unsent in prog.o
      _sport_new in test_common.o
      _send_packets_one_by_one in test_common.o
      _pba_allocate in test_common.o
      ...
  "___asan_init", referenced from:
      _asan.module_ctor in echo_client.o
      _asan.module_ctor in prog.o
      _asan.module_ctor in test_cert.o
      _asan.module_ctor in test_common.o
      _asan.module_ctor in liblsquic.a(lsquic_logger.o)
      _asan.module_ctor in liblsquic.a(lsquic_versions_to_string.o)
      _asan.module_ctor in liblsquic.a(lsquic_conn.o)
      ...
  "___asan_memcpy", referenced from:
      _sport_new in test_common.o
      _sport_init_server in test_common.o
      _sport_init_client in test_common.o
      _read_one_packet in test_common.o
      _proc_ancillary in test_common.o
      _setup_control_msg in test_common.o
      _lsquic_conn_copy_and_release_pi_data in liblsquic.a(lsquic_conn.o)
      ...
  "___asan_memmove", referenced from:
      _frame_std_gen_read in liblsquic.a(lsquic_stream.o)
      _lsquic_packet_out_elide_reset_stream_frames in liblsquic.a(lsquic_packet_out.o)
      _lsquic_packet_out_chop_regen in liblsquic.a(lsquic_packet_out.o)
      _move_largest_frame in liblsquic.a(lsquic_packet_out.o)
      _ietf_v1_gen_ack_frame in liblsquic.a(lsquic_parse_ietf_v1.o)
      _qeh_write_headers in liblsquic.a(lsquic_qenc_hdl.o)
      _lshpack_enc_enc_str in liblsquic.a(lshpack.o)
      ...
  "___asan_memset", referenced from:
      _main in echo_client.o
      _prog_init in prog.o
      _prog_init_server in prog.o
      _sport_new in test_common.o
      _sport_init_client in test_common.o
      _setup_control_msg in test_common.o
      _lsquic_engine_init_settings in liblsquic.a(lsquic_engine.o)
      ...
  "___asan_option_detect_stack_use_after_return", referenced from:
      _echo_client_on_read in echo_client.o
      _main in echo_client.o
      _prog_set_opt in prog.o
      _prog_process_conns in prog.o
      _prog_prep in prog.o
      _prog_init_server in prog.o
      _keylog_open in prog.o
      ...
  "___asan_register_image_globals", referenced from:
      _asan.module_ctor in echo_client.o
      _asan.module_ctor in prog.o
      _asan.module_ctor in test_cert.o
      _asan.module_ctor in test_common.o
      _asan.module_ctor in liblsquic.a(lsquic_logger.o)
      _asan.module_ctor in liblsquic.a(lsquic_versions_to_string.o)
      _asan.module_ctor in liblsquic.a(lsquic_conn.o)
      ...
  "___asan_report_load1", referenced from:
      _echo_client_on_read in echo_client.o
      _read_stdin in echo_client.o
      _keylog_open in prog.o
      _sport_init_server in test_common.o
      _sport_init_client in test_common.o
      _send_packets_one_by_one in test_common.o
      _sport_set_token in test_common.o
      ...
  "___asan_report_load16", referenced from:
      _read_data_frames in liblsquic.a(lsquic_stream.o)
      _gquic_encrypt_buf in liblsquic.a(lsquic_handshake.o)
      _verify_packet_hash in liblsquic.a(lsquic_handshake.o)
      _select_ku_label in liblsquic.a(lsquic_enc_sess_ietf.o)
      _fnv1a_inc in liblsquic.a(lsquic_crypto.o)
      _fnv1a_128_3 in liblsquic.a(lsquic_crypto.o)
      _serialize_fnv128_short in liblsquic.a(lsquic_crypto.o)
      ...
  "___asan_report_load2", referenced from:
      _prog_set_opt in prog.o
      _prog_connect in prog.o
      _sport_init_server in test_common.o
      _sport_init_client in test_common.o
      _lsquic_conn_copy_and_release_pi_data in liblsquic.a(lsquic_conn.o)
      _send_packets_out in liblsquic.a(lsquic_engine.o)
      _lsquic_engine_packet_in in liblsquic.a(lsquic_engine.o)
      ...
  "___asan_report_load4", referenced from:
      _echo_client_on_conn_closed in echo_client.o
      _echo_client_on_close in echo_client.o
      _main in echo_client.o
      _usage in echo_client.o
      _read_stdin in echo_client.o
      _prog_print_common_options in prog.o
      _prog_set_opt in prog.o
      ...
  "___asan_report_load8", referenced from:
      _echo_client_on_conn_closed in echo_client.o
      _echo_client_on_new_stream in echo_client.o
      _echo_client_on_read in echo_client.o
      _echo_client_on_write in echo_client.o
      _echo_client_on_close in echo_client.o
      _main in echo_client.o
      _read_stdin in echo_client.o
      ...
  "___asan_report_load_n", referenced from:
      _stream_dispatch_read_events_loop in liblsquic.a(lsquic_stream.o)
      _stream_dispatch_write_events_loop in liblsquic.a(lsquic_stream.o)
      _stream_progress in liblsquic.a(lsquic_stream.o)
      _mini_conn_ci_tick in liblsquic.a(lsquic_mini_conn.o)
      _mini_conn_ci_packet_in in liblsquic.a(lsquic_mini_conn.o)
      _mini_conn_ci_packet_sent in liblsquic.a(lsquic_mini_conn.o)
      _mini_conn_ci_destroy in liblsquic.a(lsquic_mini_conn.o)
      ...
  "___asan_report_store1", referenced from:
      _prog_set_opt in prog.o
      _load_cert in test_cert.o
      _sport_new in test_common.o
      _sport_init_client in test_common.o
      _sport_set_token in test_common.o
      _lsquic_cid2str in liblsquic.a(lsquic_logger.o)
      _lsquic_logger_lopt in liblsquic.a(lsquic_logger.o)
      ...
  "___asan_report_store16", referenced from:
      _gquic_encrypt_buf in liblsquic.a(lsquic_handshake.o)
      _verify_packet_hash in liblsquic.a(lsquic_handshake.o)
      _fnv1a_inc in liblsquic.a(lsquic_crypto.o)
      _fnv1a_128_3 in liblsquic.a(lsquic_crypto.o)
      _serialize_fnv128_short in liblsquic.a(lsquic_crypto.o)
      _make_uint128 in liblsquic.a(lsquic_crypto.o)
      _lsqpack_dec_enc_in in liblsquic.a(lsqpack.o)
      ...
  "___asan_report_store2", referenced from:
      _prog_set_opt in prog.o
      _sport_new in test_common.o
      _sport_init_client in test_common.o
      _find_conn_by_addr in liblsquic.a(lsquic_engine.o)
      _add_conn_to_hash in liblsquic.a(lsquic_engine.o)
      _copy_packet in liblsquic.a(lsquic_engine.o)
      _hq_filter_df in liblsquic.a(lsquic_stream.o)
      ...
  "___asan_report_store4", referenced from:
      _prog_init in prog.o
      _prog_set_opt in prog.o
      _prog_add_sport in prog.o
      _prog_process_conns in prog.o
      _sport_new in test_common.o
      _sport_init_server in test_common.o
      _allocate_packets_in in test_common.o
      ...
  "___asan_report_store8", referenced from:
      _echo_client_on_new_conn in echo_client.o
      _echo_client_on_new_stream in echo_client.o
      _echo_client_on_write in echo_client.o
      _main in echo_client.o
      _prog_init in prog.o
      _prog_set_opt in prog.o
      _prog_add_sport in prog.o
      ...
  "___asan_report_store_n", referenced from:
      _stream_dispatch_read_events_loop in liblsquic.a(lsquic_stream.o)
      _stream_dispatch_write_events_loop in liblsquic.a(lsquic_stream.o)
      _progress_eq in liblsquic.a(lsquic_stream.o)
  "___asan_set_shadow_00", referenced from:
      _main in echo_client.o
      _keylog_open in prog.o
      _lsquic_logger_log3 in liblsquic.a(lsquic_logger.o)
      _lsquic_logger_log2 in liblsquic.a(lsquic_logger.o)
      _lsquic_logger_log1 in liblsquic.a(lsquic_logger.o)
      _lsquic_logger_log0 in liblsquic.a(lsquic_logger.o)
      _process_connections in liblsquic.a(lsquic_engine.o)
      ...
  "___asan_set_shadow_f5", referenced from:
      _send_packets_out in liblsquic.a(lsquic_engine.o)
      _drop_all_mini_conns in liblsquic.a(lsquic_engine.o)
      _lsquic_engine_earliest_adv_tick in liblsquic.a(lsquic_engine.o)
      _find_or_create_conn in liblsquic.a(lsquic_engine.o)
      _lsquic_enc_session_gen_chlo in liblsquic.a(lsquic_handshake.o)
      _get_valid_scfg in liblsquic.a(lsquic_handshake.o)
      _gen_rej1_data in liblsquic.a(lsquic_handshake.o)
      ...
  "___asan_set_shadow_f8", referenced from:
      _main in echo_client.o
      _keylog_open in prog.o
      _lsquic_logger_log3 in liblsquic.a(lsquic_logger.o)
      _lsquic_logger_log2 in liblsquic.a(lsquic_logger.o)
      _lsquic_logger_log1 in liblsquic.a(lsquic_logger.o)
      _lsquic_logger_log0 in liblsquic.a(lsquic_logger.o)
      _process_connections in liblsquic.a(lsquic_engine.o)
      ...
  "___asan_stack_free_5", referenced from:
      _keylog_open in prog.o
      _lsquic_engine_send_unsent_packets in liblsquic.a(lsquic_engine.o)
      _get_sni_SSL_CTX in liblsquic.a(lsquic_handshake.o)
      _iquic_esf_decrypt_packet in liblsquic.a(lsquic_enc_sess_ietf.o)
      _continue_handshake in liblsquic.a(lsquic_mini_conn.o)
  "___asan_stack_free_6", referenced from:
      _process_connections in liblsquic.a(lsquic_engine.o)
  "___asan_stack_free_7", referenced from:
      _readf_cb in liblsquic.a(lsquic_enc_sess_ietf.o)
      _lsquic_ev_log_generated_ack_frame in liblsquic.a(lsquic_ev_log.o)
      _process_streams_read_events in liblsquic.a(lsquic_full_conn.o)
      _process_streams_ready_to_send in liblsquic.a(lsquic_full_conn.o)
      _process_streams_write_events in liblsquic.a(lsquic_full_conn.o)
      _process_streams_read_events in liblsquic.a(lsquic_full_conn_ietf.o)
      _process_streams_ready_to_send in liblsquic.a(lsquic_full_conn_ietf.o)
      ...
  "___asan_stack_free_8", referenced from:
      _lsquic_logger_log3 in liblsquic.a(lsquic_logger.o)
      _lsquic_logger_log2 in liblsquic.a(lsquic_logger.o)
      _lsquic_logger_log1 in liblsquic.a(lsquic_logger.o)
      _lsquic_logger_log0 in liblsquic.a(lsquic_logger.o)
  "___asan_stack_malloc_0", referenced from:
      _echo_client_on_read in echo_client.o
      _allocate_packets_in in test_common.o
      _read_handler in test_common.o
      _find_conn_by_addr in liblsquic.a(lsquic_engine.o)
      _destroy_conn in liblsquic.a(lsquic_engine.o)
      _cub_add_cids_from_cces in liblsquic.a(lsquic_engine.o)
      _lsquic_engine_packet_in in liblsquic.a(lsquic_engine.o)
      ...
  "___asan_stack_malloc_1", referenced from:
      _prog_process_conns in prog.o
      _prog_init_server in prog.o
      _sport_init_server in test_common.o
      _read_one_packet in test_common.o
      _setup_control_msg in test_common.o
      _lsquic_engine_connect in liblsquic.a(lsquic_engine.o)
      _process_packet_in in liblsquic.a(lsquic_engine.o)
      ...
  "___asan_stack_malloc_2", referenced from:
      _prog_set_opt in prog.o
      _prog_prep in prog.o
      _sport_new in test_common.o
      _sport_init_client in test_common.o
      _send_packets_one_by_one in test_common.o
      _create_lsquic_reader_ctx in test_common.o
      _print_timestamp in liblsquic.a(lsquic_logger.o)
      ...
  "___asan_stack_malloc_3", referenced from:
      _send_packets_out in liblsquic.a(lsquic_engine.o)
      _lsquic_engine_earliest_adv_tick in liblsquic.a(lsquic_engine.o)
      _find_or_create_conn in liblsquic.a(lsquic_engine.o)
      _lsquic_enc_session_gen_chlo in liblsquic.a(lsquic_handshake.o)
      _get_valid_scfg in liblsquic.a(lsquic_handshake.o)
      _gen_shlo_data in liblsquic.a(lsquic_handshake.o)
      _setup_handshake_keys in liblsquic.a(lsquic_enc_sess_ietf.o)
      ...
  "___asan_stack_malloc_4", referenced from:
      _drop_all_mini_conns in liblsquic.a(lsquic_engine.o)
      _gen_rej1_data in liblsquic.a(lsquic_handshake.o)
      _get_peer_transport_params in liblsquic.a(lsquic_enc_sess_ietf.o)
      _handshake_ok in liblsquic.a(lsquic_full_conn_ietf.o)
      _split_largest_frame in liblsquic.a(lsquic_packet_out.o)
      _lsquic_qlog_packet_rx in liblsquic.a(lsquic_qlog.o)
  "___asan_stack_malloc_5", referenced from:
      _main in echo_client.o
      _keylog_open in prog.o
      _lsquic_engine_send_unsent_packets in liblsquic.a(lsquic_engine.o)
      _get_sni_SSL_CTX in liblsquic.a(lsquic_handshake.o)
      _iquic_esf_decrypt_packet in liblsquic.a(lsquic_enc_sess_ietf.o)
      _continue_handshake in liblsquic.a(lsquic_mini_conn.o)
  "___asan_stack_malloc_6", referenced from:
      _process_connections in liblsquic.a(lsquic_engine.o)
  "___asan_stack_malloc_7", referenced from:
      _readf_cb in liblsquic.a(lsquic_enc_sess_ietf.o)
      _lsquic_ev_log_generated_ack_frame in liblsquic.a(lsquic_ev_log.o)
      _process_streams_read_events in liblsquic.a(lsquic_full_conn.o)
      _process_streams_ready_to_send in liblsquic.a(lsquic_full_conn.o)
      _process_streams_write_events in liblsquic.a(lsquic_full_conn.o)
      _process_streams_read_events in liblsquic.a(lsquic_full_conn_ietf.o)
      _process_streams_ready_to_send in liblsquic.a(lsquic_full_conn_ietf.o)
      ...
  "___asan_stack_malloc_8", referenced from:
      _lsquic_logger_log3 in liblsquic.a(lsquic_logger.o)
      _lsquic_logger_log2 in liblsquic.a(lsquic_logger.o)
      _lsquic_logger_log1 in liblsquic.a(lsquic_logger.o)
      _lsquic_logger_log0 in liblsquic.a(lsquic_logger.o)
  "___asan_unregister_image_globals", referenced from:
      _asan.module_dtor in echo_client.o
      _asan.module_dtor in prog.o
      _asan.module_dtor in test_cert.o
      _asan.module_dtor in test_common.o
      _asan.module_dtor in liblsquic.a(lsquic_logger.o)
      _asan.module_dtor in liblsquic.a(lsquic_versions_to_string.o)
      _asan.module_dtor in liblsquic.a(lsquic_conn.o)
      ...
  "___asan_version_mismatch_check_apple_1000", referenced from:
      _asan.module_ctor in echo_client.o
      _asan.module_ctor in prog.o
      _asan.module_ctor in test_cert.o
      _asan.module_ctor in test_common.o
      _asan.module_ctor in liblsquic.a(lsquic_logger.o)
      _asan.module_ctor in liblsquic.a(lsquic_versions_to_string.o)
      _asan.module_ctor in liblsquic.a(lsquic_conn.o)
      ...
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)