### PR TITLE
Android support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ IF (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     IF(NOT GLIBC_VERSION EQUAL "" AND GLIBC_VERSION VERSION_LESS 2.17)
         SET(LIBS ${LIBS} rt)
     ENDIF()
+ELSEIF (CMAKE_SYSTEM_NAME STREQUAL "Android")
+    # for android-ndk >= r19b
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY "BOTH")
+    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE "BOTH")
+    set(CMAKE_FIND_ROOT_PATH_MODE_PATH "BOTH")
 ENDIF()
 
 IF("${CMAKE_BUILD_TYPE}" STREQUAL "")
@@ -166,6 +171,7 @@ IF(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")
     link_directories( /usr/local/lib )
 ENDIF()
 
+IF (NOT TESTS STREQUAL "NO")
 # Find zlib and libevent header files and library files
 # TODO: libevent is not strictly necessary to build the library.
 FIND_PATH(ZLIB_INCLUDE_DIR NAMES zlib.h)
@@ -247,11 +253,12 @@ TARGET_LINK_LIBRARIES(md5_client  ${LIBS})
 TARGET_LINK_LIBRARIES(echo_server ${LIBS})
 TARGET_LINK_LIBRARIES(echo_client ${LIBS})
 
+add_subdirectory(test)
+ENDIF() # TESTS
+
 add_subdirectory(src)
 
-add_subdirectory(test)
-
-IF(CMAKE_BUILD_TYPE STREQUAL "Debug")
+IF(CMAKE_BUILD_TYPE STREQUAL "Debug" AND NOT TESTS STREQUAL "NO")
     # Our test framework relies on assertions, only compile if assertions are
     # enabled.
     #

--- a/src/liblsquic/lsquic_parse_ietf_v1.c
+++ b/src/liblsquic/lsquic_parse_ietf_v1.c
@@ -1030,7 +1030,7 @@ ietf_v1_gen_ack_frame (unsigned char *outbuf, size_t outbuf_sz,
         rsize = range->high - range->low;
         a = vint_val2bits(gap - 1);
         b = vint_val2bits(rsize);
-        if (ecn_needs + (1 << a) + (1 << b) > AVAIL())
+        if (ecn_needs + (1 << a) + (1 << b) > (unsigned)AVAIL())
             break;
         if (addl_ack_blocks == VINT_MAX_ONE_BYTE)
         {
@@ -1055,7 +1055,7 @@ ietf_v1_gen_ack_frame (unsigned char *outbuf, size_t outbuf_sz,
 
     if (ecn_counts)
     {
-        assert(ecn_needs <= AVAIL());
+        assert(ecn_needs <= (unsigned)AVAIL());
         for (ecn = 1; ecn <= 3; ++ecn)
         {
             vint_write(p, ecn_counts[ecnmap[ecn]], bits[ecnmap[ecn]], 1 << bits[ecnmap[ecn]]);


### PR DESCRIPTION
Adds support for Android Cmake.

Two primary changes:
1. Supressed test compilation for Android ... `lsquic/test` requires libevent and it is not included by default in android NDK. So added an option `-DTESTS=NO` to suppress test compilation. The test suppression is useful even for linux/win when someone wants to just generate the libs. `-TESTS=NO` works on all platforms.
2. `CMakeLists.txt` for Android toolchain.
3. clang (used by android ndk) gives error for unsigned ... signed comparison and I have added a couple of typecasts in one c code file.

Tested with `android-ndk-r21b` for both debug/release. Compilation command used:
```
$ cd lsquic
$ cmake -DTESTS=NO -DBORINGSSL_DIR=../boringssl -DCMAKE_TOOLCHAIN_FILE=$NDK/build/cmake/android.toolchain.cmake -DANDROID_ABI=armeabi-v7a  . #Debug mode
```
For release mode add: -DCMAKE_BUILD_TYPE=Release and the lib compiles fine.

For linking, I have used my own app links with liblsquic.a and internally uses epoll (and not libevent). 

Binaries tested on Huawei Mate 20 Pro.