### PR TITLE
fix for BORINGSSL_LIB and BORINGSSL_INCLUDE paths with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,8 @@ ELSE()
         ELSE()
             FIND_LIBRARY(BORINGSSL_LIB_${LIB_NAME}
                 NAMES lib${LIB_NAME}.a
-                PATHS ${BORINGSSL_LIB}/${LIB_NAME}
+                PATHS ${BORINGSSL_LIB}
+                PATH_SUFFIXES ${LIB_NAME}
                 NO_DEFAULT_PATH)
         ENDIF()
         IF(BORINGSSL_LIB_${LIB_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ ELSE()
         ELSE()
             FIND_LIBRARY(BORINGSSL_LIB_${LIB_NAME}
                 NAMES lib${LIB_NAME}.a
-                PATHS ${BORINGSSL_LIB}
+                PATHS ${BORINGSSL_LIB}/${LIB_NAME}
                 NO_DEFAULT_PATH)
         ENDIF()
         IF(BORINGSSL_LIB_${LIB_NAME})


### PR DESCRIPTION
With lsquic cmake you can specify BORINGSSL_LIB and BORINGSSL_INCLUDE paths separately, but it has a small glitch currently. This PR fixes it.
 
Relevant other [discussion](https://github.com/litespeedtech/lsquic/issues/133#issuecomment-630257700).