### PR TITLE
UDP GSO support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,8 @@ ELSE()
         ELSE()
             FIND_LIBRARY(BORINGSSL_LIB_${LIB_NAME}
                 NAMES lib${LIB_NAME}.a
-                PATHS ${BORINGSSL_LIB}/${LIB_NAME}
+                PATHS ${BORINGSSL_LIB}
+                PATH_SUFFIXES ${LIB_NAME}
                 NO_DEFAULT_PATH)
         ENDIF()
         IF(BORINGSSL_LIB_${LIB_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,7 @@ ELSE()
         ELSE()
             FIND_LIBRARY(BORINGSSL_LIB_${LIB_NAME}
                 NAMES lib${LIB_NAME}.a
-                PATHS ${BORINGSSL_LIB}
+                PATHS ${BORINGSSL_LIB}/${LIB_NAME}
                 NO_DEFAULT_PATH)
         ENDIF()
         IF(BORINGSSL_LIB_${LIB_NAME})

--- a/bin/prog.c
+++ b/bin/prog.c
@@ -3,6 +3,7 @@
 #ifndef WIN32
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <netinet/udp.h>
 #include <signal.h>
 #endif
 #include <errno.h>
@@ -156,6 +157,8 @@ prog_print_common_options (const struct prog *prog, FILE *out)
 "                   sndbuf=12345    # Sets SO_SNDBUF\n"
 "                   rcvbuf=12345    # Sets SO_RCVBUF\n"
 "   -W          Use stock PMI (malloc & free)\n"
+"   -O BURST    Use UDP GSO (if available). BURST factor is the max packets\n"
+"               that can be aggregated in single sendmsg.\n"
     );
 
 #if HAVE_SENDMMSG
@@ -211,6 +214,34 @@ prog_print_common_options (const struct prog *prog, FILE *out)
     );
 }
 
+#if HAVE_GSO
+/* Test at runtime if the GSO support is available. setsockopt(UDP_SEGMENT)
+ * should be successful if the GSO is supported.
+ * Returns non-zero if GSO supported. */
+int supports_gso(void)
+{
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    int gso_size = 1400; // just for test
+
+    if(fd < 0) {
+        LSQ_ERROR("weird! socket failed");
+        return 0;
+    }
+    if (setsockopt(fd, SOL_UDP, UDP_SEGMENT, &gso_size, sizeof(gso_size))) {
+        LSQ_INFO("gso setsockopt failed. GSO not supp");
+        close(fd);
+        return 0;
+    }
+    LSQ_INFO("GSO is supported");
+    close(fd);
+    return 1;
+}
+#else
+int supports_gso(void)
+{
+    return 0;
+}
+#endif  // HAVE_GSO
 
 int
 prog_set_opt (struct prog *prog, int opt, const char *arg)
@@ -220,6 +251,11 @@ prog_set_opt (struct prog *prog, int opt, const char *arg)
 
     switch (opt)
     {
+    case 'O':
+        if(supports_gso()) {
+            prog->prog_gso_burst = (unsigned)atoi(arg);
+        }
+        return 0;
 #if LSQUIC_DONTFRAG_SUPPORTED
     case 'D':
         {

--- a/bin/prog.h
+++ b/bin/prog.h
@@ -25,6 +25,7 @@ struct prog
     unsigned short                  prog_max_packet_size;
     int                             prog_version_cleared;
     unsigned long                   prog_read_count;
+    unsigned                        prog_gso_burst;
 #if HAVE_SENDMMSG
     int                             prog_use_sendmmsg;
 #endif
@@ -75,7 +76,7 @@ prog_init (struct prog *, unsigned lsquic_engine_flags, struct sport_head *,
 #   define IP_DONTFRAG_FLAG ""
 #endif
 
-#define PROG_OPTS "i:km:c:y:L:l:o:H:s:S:Y:z:G:W" RECVMMSG_FLAG SENDMMSG_FLAG \
+#define PROG_OPTS "O:i:km:c:y:L:l:o:H:s:S:Y:z:G:W" RECVMMSG_FLAG SENDMMSG_FLAG \
                                                             IP_DONTFRAG_FLAG
 
 /* Returns:

--- a/bin/test_common.h
+++ b/bin/test_common.h
@@ -125,4 +125,16 @@ destroy_lsquic_reader_ctx (struct reader_ctx *ctx);
 #define LITESPEED_ID "lsquic" "/" TOSTRING(LSQUIC_MAJOR_VERSION) "." \
             TOSTRING(LSQUIC_MINOR_VERSION) "." TOSTRING(LSQUIC_PATCH_VERSION)
 
+#ifndef WIN32
+#ifndef UDP_SEGMENT
+#define UDP_SEGMENT 103
+#endif
+#endif
+
+#ifndef HAVE_GSO
+#if defined(SOL_UDP) && defined(UDP_SEGMENT)
+#define HAVE_GSO 1
+#endif
+#endif
+
 #endif


### PR DESCRIPTION
## Implementation highlights

* Batching iovecs to utilize UDP-GSO in `send_packets_out` callback
      * Packets of equal length are batched together. The last packet can be of a smaller length.
      * `setup_ctl_msg` updated to set the CMSG hdr of UDP_SEGMENT with gso_size passed as pktlen
      * send_gso internally leverages `send_packets_one_by_one()` to send batched iovecs with the GSO CMSG.
* -O BURST command-line option added ... BURST is the max packets to coalesce in single call.
      * Even if -O is specified, a runtime check is added to check for UDP-GSO support since the binaries may be transferred to another system using a different kernel.

## Preliminary Data
Scenario: Transfer 1GB file locally using http_client/http_server app and use perf record to profile only the server who serves the file.

Note: A lot depends on how the sample application calls the `stream_write()/stream_flush()` APIs. However, without any changes to app I was able to get an aggregation of roughly ~6 packets. I tried GSO with burst size of 10 packets and 20 packets. One can check the aggregation efficiency by enabling debug logs and checking `LSQ_DEBUG("GSO with burst:%d", vcnt)`.

Following is the perf-record and diff for {send_packets_one_by_one()/send_packets_using_sendmmsg()/send_packets_using_gso()}

![image](https://user-images.githubusercontent.com/9133227/82889544-7a4fcd00-9f7d-11ea-9399-e99023b76e52.png)

I have my own application which simulates RPC scenario with user-space lsquic pacing disabled and simulates long responses involving 1.2KB to 100KB and I easily get a batching/aggregation of 10/20/30 packets and much better CPU usage reduction.