### PR TITLE
GSO-Friendly Packets Out Memory

### DIFF
--- a/bin/test_common.c
+++ b/bin/test_common.c
@@ -2043,7 +2043,7 @@ pba_init (struct packout_buf_allocator *pba, unsigned max)
 
 
 void *
-pba_allocate (void *packout_buf_allocator, void *peer_ctx, lsquic_conn_get_ctx *conn_ctx, unsigned short size,
+pba_allocate (void *packout_buf_allocator, void *peer_ctx, lsquic_conn_ctx_t *conn_ctx, unsigned short size,
                                                                 char is_ipv6)
 {
     struct packout_buf_allocator *const pba = packout_buf_allocator;

--- a/bin/test_common.c
+++ b/bin/test_common.c
@@ -2043,7 +2043,7 @@ pba_init (struct packout_buf_allocator *pba, unsigned max)
 
 
 void *
-pba_allocate (void *packout_buf_allocator, void *peer_ctx, lsquic_conn_ctx_t *conn_ctx, unsigned short size,
+pba_allocate (void *packout_buf_allocator, void *peer_ctx, void *conn_ctx, unsigned short size,
                                                                 char is_ipv6)
 {
     struct packout_buf_allocator *const pba = packout_buf_allocator;

--- a/bin/test_common.c
+++ b/bin/test_common.c
@@ -2043,7 +2043,7 @@ pba_init (struct packout_buf_allocator *pba, unsigned max)
 
 
 void *
-pba_allocate (void *packout_buf_allocator, void *peer_ctx, unsigned short size,
+pba_allocate (void *packout_buf_allocator, void *peer_ctx, lsquic_conn_get_ctx *conn_ctx, unsigned short size,
                                                                 char is_ipv6)
 {
     struct packout_buf_allocator *const pba = packout_buf_allocator;

--- a/bin/test_common.h
+++ b/bin/test_common.h
@@ -115,7 +115,7 @@ void
 pba_init (struct packout_buf_allocator *, unsigned max);
 
 void *
-pba_allocate (void *packout_buf_allocator, void*, unsigned short, char);
+pba_allocate (void *packout_buf_allocator, void*, lsquic_conn_get_ctx *conn_ctx, unsigned short, char);
 
 void
 pba_release (void *packout_buf_allocator, void *, void *obj, char);

--- a/bin/test_common.h
+++ b/bin/test_common.h
@@ -111,6 +111,10 @@ struct packout_buf_allocator
     SLIST_HEAD(, packout_buf)   free_packout_bufs;
 };
 
+struct lsquic_conn_ctx {
+
+};
+
 void
 pba_init (struct packout_buf_allocator *, unsigned max);
 

--- a/bin/test_common.h
+++ b/bin/test_common.h
@@ -111,15 +111,11 @@ struct packout_buf_allocator
     SLIST_HEAD(, packout_buf)   free_packout_bufs;
 };
 
-struct lsquic_conn_ctx {
-
-};
-
 void
 pba_init (struct packout_buf_allocator *, unsigned max);
 
 void *
-pba_allocate (void *packout_buf_allocator, void*, lsquic_conn_ctx_t *conn_ctx, unsigned short, char);
+pba_allocate (void *packout_buf_allocator, void*, void *conn_ctx, unsigned short, char);
 
 void
 pba_release (void *packout_buf_allocator, void *, void *obj, char);

--- a/bin/test_common.h
+++ b/bin/test_common.h
@@ -115,7 +115,7 @@ void
 pba_init (struct packout_buf_allocator *, unsigned max);
 
 void *
-pba_allocate (void *packout_buf_allocator, void*, lsquic_conn_get_ctx *conn_ctx, unsigned short, char);
+pba_allocate (void *packout_buf_allocator, void*, lsquic_conn_ctx_t *conn_ctx, unsigned short, char);
 
 void
 pba_release (void *packout_buf_allocator, void *, void *obj, char);

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -2008,7 +2008,7 @@ Miscellaneous Types
 
     If not specified, malloc() and free() are used.
 
-    .. member:: void *  (*pmi_allocate) (void *pmi_ctx, void *peer_ctx, unsigned short sz, char is_ipv6)
+    .. member:: void *  (*pmi_allocate) (void *pmi_ctx, void *peer_ctx, lsquic_conn_get_ctx *conn_ctx, unsigned short sz, char is_ipv6)
 
         Allocate buffer for sending.
 

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -1035,7 +1035,7 @@ struct lsquic_packout_mem_if
     /**
      * Allocate buffer for sending.
      */
-    void *  (*pmi_allocate) (void *pmi_ctx, void *peer_ctx, unsigned short sz,
+    void *  (*pmi_allocate) (void *pmi_ctx, void *peer_ctx, lsquic_conn_ctx_t *, unsigned short sz,
                                                                 char is_ipv6);
     /**
      * This function is used to release the allocated buffer after it is

--- a/src/liblsquic/lsquic_enc_sess_ietf.c
+++ b/src/liblsquic/lsquic_enc_sess_ietf.c
@@ -1973,7 +1973,7 @@ iquic_esf_encrypt_packet (enc_session_t *enc_session_p,
     dst_sz = lconn->cn_pf->pf_packout_size(lconn, packet_out);
     ipv6 = NP_IS_IPv6(packet_out->po_path);
     dst = enpub->enp_pmi->pmi_allocate(enpub->enp_pmi_ctx,
-                                packet_out->po_path->np_peer_ctx, dst_sz, ipv6);
+                                packet_out->po_path->np_peer_ctx, lsquic_conn_get_ctx(lconn), dst_sz, ipv6);
     if (!dst)
     {
         LSQ_DEBUG("could not allocate memory for outgoing packet of size %zd",

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -1955,7 +1955,7 @@ copy_packet (struct lsquic_engine *engine, struct lsquic_conn *conn,
     }
 
     packet_out->po_enc_data = engine->pub.enp_pmi->pmi_allocate(
-                    engine->pub.enp_pmi_ctx, packet_out->po_path->np_peer_ctx,
+                    engine->pub.enp_pmi_ctx, packet_out->po_path->np_peer_ctx, lsquic_conn_get_ctx(conn),
                     packet_out->po_data_sz, ipv6);
     if (!packet_out->po_enc_data)
     {

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -466,7 +466,7 @@ free_packet (void *ctx, void *conn_ctx, void *packet_data, char is_ipv6)
 
 
 static void *
-malloc_buf (void *ctx, void *conn_ctx, unsigned short size, char is_ipv6)
+malloc_buf (void *ctx, void *conn_ctx, lsquic_conn_ctx_t *conn_ctx, unsigned short size, char is_ipv6)
 {
     return malloc(size);
 }

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -466,7 +466,7 @@ free_packet (void *ctx, void *conn_ctx, void *packet_data, char is_ipv6)
 
 
 static void *
-malloc_buf (void *ctx, void *conn_ctx, lsquic_conn_ctx_t *conn_ctx, unsigned short size, char is_ipv6)
+malloc_buf (void *ctx, void *peer_ctx, lsquic_conn_ctx_t *conn_ctx, unsigned short size, char is_ipv6)
 {
     return malloc(size);
 }

--- a/src/liblsquic/lsquic_handshake.c
+++ b/src/liblsquic/lsquic_handshake.c
@@ -3746,7 +3746,7 @@ gquic_encrypt_packet (enc_session_t *enc_session_p,
         return ENCPA_BADCRYPT;  /* To cause connection to close */
     ipv6 = NP_IS_IPv6(packet_out->po_path);
     buf = enpub->enp_pmi->pmi_allocate(enpub->enp_pmi_ctx,
-                                packet_out->po_path->np_peer_ctx, bufsz, ipv6);
+                                packet_out->po_path->np_peer_ctx, lsquic_conn_get_ctx(lconn), bufsz, ipv6);
     if (!buf)
     {
         LSQ_DEBUG("could not allocate memory for outgoing packet of size %zd",
@@ -3944,7 +3944,7 @@ gquic2_esf_encrypt_packet (enc_session_t *enc_session_p,
     dst_sz = lconn->cn_pf->pf_packout_size(lconn, packet_out);
     ipv6 = NP_IS_IPv6(packet_out->po_path);
     dst = enpub->enp_pmi->pmi_allocate(enpub->enp_pmi_ctx,
-                                packet_out->po_path->np_peer_ctx, dst_sz, ipv6);
+                                packet_out->po_path->np_peer_ctx, lsquic_conn_get_ctx(lconn), dst_sz, ipv6);
     if (!dst)
     {
         LSQ_DEBUG("could not allocate memory for outgoing packet of size %zd",


### PR DESCRIPTION
this trivial patch enables the batching of packets out into a persistent buffer per connection, for cleaner more efficient GSO.

currently there is no way to relate the `peer_ctx` back to a connection inside the `pmi_allocate` callback, so the best you can do is a pool of packet buffers. This can lead to ~40+ unique packet buffers being passed via sendmsg into the kernel and just as many unique copies.

or one could construct a contiguous buffer of all packets for GSO within the `ea_packets_out` at the expense of all those copies.

and all is complicated further by using io_uring given the asynchronous sendmsg completions.

this patch relies on the assumption of sequence. That for a given connection, the sequence in which packet buffers are requested from `pmi_allocate` matches the order in which they are passed to `ea_packets_out`.

now all you need to do is group packets by connection in your `ea_packets_out` callback, then calculate the contiguous buffer they constitute into a new `struct iov_vec` and pass it into `sendmsg`.