### PR TITLE
Connection ID Steering

### DIFF
--- a/bin/test_common.c
+++ b/bin/test_common.c
@@ -2043,7 +2043,7 @@ pba_init (struct packout_buf_allocator *pba, unsigned max)
 
 
 void *
-pba_allocate (void *packout_buf_allocator, void *peer_ctx, lsquic_conn_ctx_t * conn_ctx, unsigned short size,
+pba_allocate (void *packout_buf_allocator, void *peer_ctx, unsigned short size,
                                                                 char is_ipv6)
 {
     struct packout_buf_allocator *const pba = packout_buf_allocator;

--- a/bin/test_common.c
+++ b/bin/test_common.c
@@ -2043,7 +2043,7 @@ pba_init (struct packout_buf_allocator *pba, unsigned max)
 
 
 void *
-pba_allocate (void *packout_buf_allocator, void *peer_ctx, unsigned short size,
+pba_allocate (void *packout_buf_allocator, void *peer_ctx, lsquic_conn_ctx_t * conn_ctx, unsigned short size,
                                                                 char is_ipv6)
 {
     struct packout_buf_allocator *const pba = packout_buf_allocator;

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -1190,7 +1190,7 @@ struct lsquic_engine_api
     /**
      * Optional interface to control the creation of connection IDs
      */
-    void  (*ea_generate_cid)(lsquic_cid_t *);
+    void  (*es_generate_scid)(lsquic_conn_t *, lsquic_cid_t *, unsigned);
 
     /**
      * Optional interface to report new and old source connection IDs.

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -1186,6 +1186,12 @@ struct lsquic_engine_api
      */
     const struct lsquic_packout_mem_if  *ea_pmi;
     void                                *ea_pmi_ctx;
+
+    /**
+     * Optional interface to control the creation of connection IDs
+     */
+    void  (*ea_generate_cid)(lsquic_cid_t *);
+
     /**
      * Optional interface to report new and old source connection IDs.
      */

--- a/src/liblsquic/lsquic_enc_sess_ietf.c
+++ b/src/liblsquic/lsquic_enc_sess_ietf.c
@@ -554,8 +554,11 @@ gen_trans_params (struct enc_sess_iquic *enc_sess, unsigned char *buf,
             cce->cce_seqno = seqno + 1;
             cce->cce_flags = CCE_SEQNO;
 
-            if (enc_sess->esi_enpub->enp_generate_cid) enc_sess->esi_enpub->enp_generate_cid(&cce->cce_cid);
-            else                                       lsquic_generate_cid(&cce->cce_cid, enc_sess->esi_enpub->enp_settings.es_scid_len);
+            if (enc_sess->esi_enpub->enp_generate_scid) 
+                enc_sess->esi_enpub->enp_generate_scid(enc_sess->esi_conn, &cce->cce_cid, enc_sess->esi_enpub->enp_settings.es_scid_len);
+            else 
+                lsquic_generate_cid(&cce->cce_cid, enc_sess->esi_enpub->enp_settings.es_scid_len);
+            
             
             /* Don't add to hash: migration must not start until *after*
              * handshake is complete.

--- a/src/liblsquic/lsquic_enc_sess_ietf.c
+++ b/src/liblsquic/lsquic_enc_sess_ietf.c
@@ -553,8 +553,10 @@ gen_trans_params (struct enc_sess_iquic *enc_sess, unsigned char *buf,
             }
             cce->cce_seqno = seqno + 1;
             cce->cce_flags = CCE_SEQNO;
-            lsquic_generate_cid(&cce->cce_cid,
-                            enc_sess->esi_enpub->enp_settings.es_scid_len);
+
+            if (enc_sess->esi_enpub->enp_generate_cid) enc_sess->esi_enpub->enp_generate_cid(&cce->cce_cid);
+            else                                       lsquic_generate_cid(&cce->cce_cid, enc_sess->esi_enpub->enp_settings.es_scid_len);
+            
             /* Don't add to hash: migration must not start until *after*
              * handshake is complete.
              */

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -576,6 +576,9 @@ lsquic_engine_new (unsigned flags,
     engine->pub.enp_lookup_cert  = api->ea_lookup_cert;
     engine->pub.enp_cert_lu_ctx  = api->ea_cert_lu_ctx;
     engine->pub.enp_get_ssl_ctx  = api->ea_get_ssl_ctx;
+
+    if (api->ea_generate_cid) engine->pub.enp_generate_cid = api->ea_generate_cid;
+
     if (api->ea_shi)
     {
         engine->pub.enp_shi      = api->ea_shi;

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -577,7 +577,7 @@ lsquic_engine_new (unsigned flags,
     engine->pub.enp_cert_lu_ctx  = api->ea_cert_lu_ctx;
     engine->pub.enp_get_ssl_ctx  = api->ea_get_ssl_ctx;
 
-    if (api->ea_generate_cid) engine->pub.enp_generate_cid = api->ea_generate_cid;
+    engine->pub.enp_generate_scid = api->es_generate_scid;
 
     if (api->ea_shi)
     {

--- a/src/liblsquic/lsquic_engine_public.h
+++ b/src/liblsquic/lsquic_engine_public.h
@@ -44,6 +44,7 @@ struct lsquic_engine_public {
     void                           *enp_stream_if_ctx;
     const struct lsquic_hset_if    *enp_hsi_if;
     void                           *enp_hsi_ctx;
+    void  (*enp_generate_cid)(lsquic_cid_t *);
     int                           (*enp_verify_cert)(void *verify_ctx,
                                             struct stack_st_X509 *chain);
     void                           *enp_verify_ctx;

--- a/src/liblsquic/lsquic_engine_public.h
+++ b/src/liblsquic/lsquic_engine_public.h
@@ -44,7 +44,7 @@ struct lsquic_engine_public {
     void                           *enp_stream_if_ctx;
     const struct lsquic_hset_if    *enp_hsi_if;
     void                           *enp_hsi_ctx;
-    void  (*enp_generate_cid)(lsquic_cid_t *);
+    void  (*enp_generate_scid)(lsquic_conn_t *, lsquic_cid_t *, unsigned);
     int                           (*enp_verify_cert)(void *verify_ctx,
                                             struct stack_st_X509 *chain);
     void                           *enp_verify_ctx;

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -1086,7 +1086,11 @@ ietf_full_conn_add_scid (struct ietf_full_conn *conn,
     }
 
     if (enpub->enp_settings.es_scid_len)
-        lsquic_generate_cid(&cce->cce_cid, enpub->enp_settings.es_scid_len);
+    {
+        if (enpub->enp_generate_cid)  enpub->enp_generate_cid(&cce->cce_cid);
+        else                          lsquic_generate_cid(&cce->cce_cid, enpub->enp_settings.es_scid_len);
+    }
+
     cce->cce_seqno = conn->ifc_scid_seqno++;
     cce->cce_flags |= CCE_SEQNO | flags;
     lconn->cn_cces_mask |= 1 << (cce - lconn->cn_cces);

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -1087,8 +1087,10 @@ ietf_full_conn_add_scid (struct ietf_full_conn *conn,
 
     if (enpub->enp_settings.es_scid_len)
     {
-        if (enpub->enp_generate_cid)  enpub->enp_generate_cid(&cce->cce_cid);
-        else                          lsquic_generate_cid(&cce->cce_cid, enpub->enp_settings.es_scid_len);
+        if (enpub->enp_generate_scid)
+            enpub->enp_generate_scid(lconn, &cce->cce_cid, enpub->enp_settings.es_scid_len);
+        else
+            lsquic_generate_cid(&cce->cce_cid, enpub->enp_settings.es_scid_len);
     }
 
     cce->cce_seqno = conn->ifc_scid_seqno++;

--- a/src/liblsquic/lsquic_mini_conn_ietf.c
+++ b/src/liblsquic/lsquic_mini_conn_ietf.c
@@ -496,7 +496,7 @@ lsquic_mini_conn_ietf_new (struct lsquic_engine_public *enpub,
      * a sequence number (0) and therefore can be retired by the client.
      */
     if (enpub->enp_settings.es_scid_len && enpub->enp_generate_scid)
-        enpub->enp_generate_scid(conn->imc_conn, &conn->imc_conn.cn_cces[1].cce_cid, enpub->enp_settings.es_scid_len);
+        enpub->enp_generate_scid(&conn->imc_conn, &conn->imc_conn.cn_cces[1].cce_cid, enpub->enp_settings.es_scid_len);
     else 
         lsquic_generate_cid(&conn->imc_conn.cn_cces[1].cce_cid, enpub->enp_settings.es_scid_len);
     

--- a/src/liblsquic/lsquic_mini_conn_ietf.c
+++ b/src/liblsquic/lsquic_mini_conn_ietf.c
@@ -495,11 +495,11 @@ lsquic_mini_conn_ietf_new (struct lsquic_engine_public *enpub,
     /* Generate new SCID. Since is not the original SCID, it is given
      * a sequence number (0) and therefore can be retired by the client.
      */
-    if (enpub->enp_settings.es_scid_len && enpub->enp_generate_cid)
-    {
-        enpub->enp_generate_cid(&conn->imc_conn.cn_cces[1].cce_cid);
-    }
-    else lsquic_generate_cid(&conn->imc_conn.cn_cces[1].cce_cid, enpub->enp_settings.es_scid_len);
+    if (enpub->enp_settings.es_scid_len && enpub->enp_generate_scid)
+        enpub->enp_generate_scid(conn->imc_conn, &conn->imc_conn.cn_cces[1].cce_cid, enpub->enp_settings.es_scid_len);
+    else 
+        lsquic_generate_cid(&conn->imc_conn.cn_cces[1].cce_cid, enpub->enp_settings.es_scid_len);
+    
 
     LSQ_DEBUGC("generated SCID %"CID_FMT" at index %u, switching to it",
                 CID_BITS(&conn->imc_conn.cn_cces[1].cce_cid), 1);

--- a/src/liblsquic/lsquic_mini_conn_ietf.c
+++ b/src/liblsquic/lsquic_mini_conn_ietf.c
@@ -495,8 +495,12 @@ lsquic_mini_conn_ietf_new (struct lsquic_engine_public *enpub,
     /* Generate new SCID. Since is not the original SCID, it is given
      * a sequence number (0) and therefore can be retired by the client.
      */
-    lsquic_generate_cid(&conn->imc_conn.cn_cces[1].cce_cid,
-                                        enpub->enp_settings.es_scid_len);
+    if (enpub->enp_settings.es_scid_len && enpub->enp_generate_cid)
+    {
+        enpub->enp_generate_cid(&conn->imc_conn.cn_cces[1].cce_cid);
+    }
+    else lsquic_generate_cid(&conn->imc_conn.cn_cces[1].cce_cid, enpub->enp_settings.es_scid_len);
+
     LSQ_DEBUGC("generated SCID %"CID_FMT" at index %u, switching to it",
                 CID_BITS(&conn->imc_conn.cn_cces[1].cce_cid), 1);
     conn->imc_conn.cn_cces[1].cce_flags = CCE_SEQNO | CCE_USED;


### PR DESCRIPTION
Under connection migration scenarios (ex. mobile client moving from LTE to WiFi) or intra-machine topology changes (ex. count of running server instances) in order to ensure stable packet steering there must be information in the connection ID to determine target machine + software server instance.

This patch allows the application to embed such information.