### PR TITLE
Link BoringSSL with `find_package`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,67 +129,8 @@ ELSE()
     SET(LIB_SUFFIX .a)
 ENDIF()
 
-IF (NOT DEFINED BORINGSSL_INCLUDE AND DEFINED BORINGSSL_DIR)
-    FIND_PATH(BORINGSSL_INCLUDE NAMES openssl/ssl.h
-                PATHS ${BORINGSSL_DIR}/include
-                NO_DEFAULT_PATH)
-ENDIF()
-# This must be done before adding other include directories to take
-# precedence over header files from other SSL installs.
-
-IF (BORINGSSL_INCLUDE)
-    MESSAGE(STATUS "BoringSSL include directory ${BORINGSSL_INCLUDE}")
-    INCLUDE_DIRECTORIES(${BORINGSSL_INCLUDE})
-ELSE()
-    MESSAGE(FATAL_ERROR "BoringSSL headers not found")
-ENDIF()
-
-IF (NOT DEFINED BORINGSSL_LIB AND DEFINED BORINGSSL_DIR)
-    FOREACH(LIB_NAME ssl crypto decrepit)
-        IF (CMAKE_SYSTEM_NAME STREQUAL Windows)
-            FIND_LIBRARY(BORINGSSL_LIB_${LIB_NAME}
-                NAMES ${LIB_NAME}
-                PATHS ${BORINGSSL_DIR}/${LIB_NAME}
-		PATH_SUFFIXES Debug Release MinSizeRel RelWithDebInfo
-                NO_DEFAULT_PATH)
-        ELSE()
-            FIND_LIBRARY(BORINGSSL_LIB_${LIB_NAME}
-                NAMES lib${LIB_NAME}${LIB_SUFFIX}
-                PATHS ${BORINGSSL_DIR}/${LIB_NAME}
-                NO_DEFAULT_PATH)
-        ENDIF()
-        IF(BORINGSSL_LIB_${LIB_NAME})
-            MESSAGE(STATUS "Found ${LIB_NAME} library: ${BORINGSSL_LIB_${LIB_NAME}}")
-        ELSE()
-            MESSAGE(STATUS "${LIB_NAME} library not found")
-        ENDIF()
-    ENDFOREACH()
-
-ELSE()
-
-
-    FOREACH(LIB_NAME ssl crypto decrepit)
-        IF (CMAKE_SYSTEM_NAME STREQUAL Windows)
-            FIND_LIBRARY(BORINGSSL_LIB_${LIB_NAME}
-                NAMES ${LIB_NAME}
-                PATHS ${BORINGSSL_LIB}
-                PATH_SUFFIXES Debug Release MinSizeRel RelWithDebInfo
-                NO_DEFAULT_PATH)
-        ELSE()
-            FIND_LIBRARY(BORINGSSL_LIB_${LIB_NAME}
-                NAMES lib${LIB_NAME}${LIB_SUFFIX}
-                PATHS ${BORINGSSL_LIB}
-                PATH_SUFFIXES ${LIB_NAME}
-                NO_DEFAULT_PATH)
-        ENDIF()
-        IF(BORINGSSL_LIB_${LIB_NAME})
-            MESSAGE(STATUS "Found ${BORINGSSL_LIB} library: ${BORINGSSL_LIB_${LIB_NAME}}")
-        ELSE()
-            MESSAGE(STATUS "${BORINGSSL_LIB} library not found")
-        ENDIF()
-    ENDFOREACH()
-
-ENDIF()
+find_package(OpenSSL REQUIRED)
+INCLUDE_DIRECTORIES(${OPENSSL_INCLUDE_DIR})
 
 SET(CMAKE_INCLUDE_CURRENT_DIR ON)
 INCLUDE_DIRECTORIES(include)
@@ -241,7 +182,7 @@ IF(EVENT_LIB)
 ELSE()
     MESSAGE(STATUS "libevent not found")
 ENDIF()
-SET(LIBS lsquic ${EVENT_LIB} ${BORINGSSL_LIB_ssl} ${BORINGSSL_LIB_crypto} ${ZLIB_LIB} ${LIBS})
+SET(LIBS lsquic ${EVENT_LIB} ${OPENSSL_SSL_LIBRARY} ${OPENSSL_CRYPTO_LIBRARY} ${ZLIB_LIB} ${LIBS})
 IF(MSVC)
 FIND_LIBRARY(PCRE_LIB pcre)
 IF(PCRE_LIB)

--- a/README.md
+++ b/README.md
@@ -36,46 +36,27 @@ Building BoringSSL
 ------------------
 
 BoringSSL is not packaged; you have to build it yourself.  The process is
-straightforward.  You will need `go` installed.
+straightforward, but we provide a helper in "./tools/build_boringssl".  You will need `go` installed.
 
-1. Clone BoringSSL by issuing the following command:
+1. You may need to install pre-requisites like zlib and libevent.
 
-```
-git clone https://boringssl.googlesource.com/boringssl
-cd boringssl
-```
-
-You may need to install pre-requisites like zlib and libevent.
-
-2. Use specific BoringSSL version
+2. Run the CMake configure step (instructions assume to be run from the root of this repository):
 
 ```
-git checkout 251b5169fd44345f455438312ec4e18ae07fd58c
+cmake -DCMAKE_INSTALL_PREFIX=tools/build_boringssl/install -Btools/build_boringssl/build -Stools/build_boringssl
 ```
 
-3. Compile the library
+_Note that with older versions of CMake (e.g. on Ubuntu 18.04), `-S` may be `-H.`._
+
+If you want to turn on optimizations, use `-DCMAKE_BUILD_TYPE=Release`, too.
+
+3. Run the CMake build step to build and install BoringSSL:
 
 ```
-cmake . &&  make
+cmake --build tools/build_boringssl/build
 ```
 
-Remember where BoringSSL sources are:
-```
-BORINGSSL=$PWD
-```
-
-If you want to turn on optimizations, do
-
-```
-cmake -DCMAKE_BUILD_TYPE=Release . && make
-```
-
-If you want to build as a library, (necessary to build lsquic itself
-as as shared library) do:
-
-```
-cmake -DBUILD_SHARED_LIBS=1 . && make
-```
+After this succeeds, using this installed BoringSSL when building LSQUIC is a matter of adding `-DCMAKE_PREFIX_PATH=tools/build_boringssl/install` in the LSQUIC configure step.
 
 Building LSQUIC Library
 -----------------------
@@ -84,38 +65,17 @@ LSQUIC's `http_client`, `http_server`, and the tests link BoringSSL
 libraries statically.  Following previous section, you can build LSQUIC
 as follows:
 
-1. Get the source code
+1. Compile the library
 
 ```
-git clone https://github.com/litespeedtech/lsquic.git
-cd lsquic
-git submodule init
-git submodule update
+cmake -DCMAKE_PREFIX_PATH=tools/build_boringssl/install -Bbuild -S.
+cmake --build build
 ```
 
-2. Compile the library
-
-Statically:
-
+2. Run tests
 
 ```
-# $BORINGSSL is the top-level BoringSSL directory from the previous step
-cmake -DBORINGSSL_DIR=$BORINGSSL .
-make
-```
-
-As a dynamic library:
-
-```
-cmake -DLSQUIC_SHARED_LIB=1 -DBORINGSSL_DIR=$BORINGSSL .
-make
-```
-
-
-3. Run tests
-
-```
-make test
+cmake --build build --target test
 ```
 
 Building with Docker

--- a/tools/build_boringssl/CMakeLists.txt
+++ b/tools/build_boringssl/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(external-boringssl)
+include(ExternalProject)
+
+set(ARG_GIT_REPOSITORY https://boringssl.googlesource.com/boringssl)
+set(ARG_GIT_TAG 251b5169fd44345f455438312ec4e18ae07fd58c)
+
+list(APPEND CMAKE_ARGS
+    "-DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}"
+    "-DBUILD_SHARED_LIBS=OFF"
+    )
+
+message(STATUS "Preparing external project \"boringssl\" with args:")
+foreach(CMAKE_ARG ${CMAKE_ARGS})
+    message(STATUS "-- ${CMAKE_ARG}")
+endforeach()
+
+ExternalProject_add(
+    boringssl
+    GIT_REPOSITORY ${ARG_GIT_REPOSITORY}
+    GIT_TAG ${ARG_GIT_TAG}
+    PREFIX boringssl
+    PATCH_COMMAND git apply ${PROJECT_SOURCE_DIR}/boringssl_install.patch
+    CMAKE_ARGS "${CMAKE_ARGS}"
+    )

--- a/tools/build_boringssl/README.md
+++ b/tools/build_boringssl/README.md
@@ -1,0 +1,41 @@
+# Build and install BoringSSL locally
+
+LSQUIC depends on BoringSSL (for now, see [this issue](https://github.com/litespeedtech/lsquic/issues/96#issuecomment-698598577) about OpenSSL), but BoringSSL is not meant as a drop-in replacement at the distro level. This means that BoringSSL must be built locally.
+
+An easy way to do that with CMake is to install BoringSSL locally, and to point `CMAKE_PREFIX_PATH` to this installation (which could contain other dependencies). That's exactly the purpose of this directory. Note that we patch BoringSSL, because it does not have any CMake install target.
+
+First, run the cmake configure command, specifying where BoringSSL should be installed (here we put it in "./install/"):
+
+```sh
+cmake -DCMAKE_INSTALL_PREFIX=install -Bbuild -S.
+```
+
+Note that with older cmake versions (e.g. on Ubuntu 18.04), `-S.` should actually be `-H.`. It is up to the reader to figure that out.
+
+Once this is done, we can run the cmake build step. It will fetch BoringSSL, patch it, build it and install it:
+
+```sh
+cmake --build build
+```
+
+If the process succeeds, BoringSSL should be installed in "./install/":
+
+```
+% tree install
+install
+├── include
+│   └── openssl
+│       ├── aead.h
+│       ├── aes.h
+│       ├── <many other header files>
+└── lib
+    ├── libcrypto.a
+    ├── libdecrepit.a
+    └── libssl.a
+```
+
+When building LSQUIC from the root of this repository, we will then tell CMake to go look for BoringSSL in this folder, with something like:
+
+```sh
+cmake -DCMAKE_PREFIX_PATH=tools/build_boringssl/install -Bbuild -S.
+```

--- a/tools/build_boringssl/boringssl_install.patch
+++ b/tools/build_boringssl/boringssl_install.patch
@@ -1,0 +1,81 @@
+commit 5d7eae3e8f45d91327c4cbc3a8eaa7be0ee748e9
+Author: Jonas Vautherin <jonas.vautherin@gmail.com>
+Date:   Wed Sep 30 00:41:07 2020 +0200
+
+    add install targets for crypto ssl decrepit
+    
+    Change-Id: Id0a9cf4da49bc2e40b2be4e1584974a86974ed0f
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index c266e1267..3945dea4a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -14,6 +14,8 @@ include(sources.cmake)
+ enable_language(C)
+ enable_language(CXX)
+ 
++include(GNUInstallDirs)
++
+ # This is a dummy target which all other targets depend on (manually - see other
+ # CMakeLists.txt files). This gives us a hook to add any targets which need to
+ # run before all other targets.
+@@ -627,3 +629,8 @@ add_custom_target(
+     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+     DEPENDS all_tests bssl_shim handshaker
+     USES_TERMINAL)
++
++install(DIRECTORY
++    include/openssl
++    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
++)
+diff --git a/crypto/CMakeLists.txt b/crypto/CMakeLists.txt
+index a872626de..7314db124 100644
+--- a/crypto/CMakeLists.txt
++++ b/crypto/CMakeLists.txt
+@@ -465,6 +465,12 @@ if(USE_CUSTOM_LIBCXX)
+   target_link_libraries(crypto libcxx)
+ endif()
+ 
++install(TARGETS crypto
++    EXPORT boringssl-targets
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)
++
+ # urandom_test is a separate binary because it needs to be able to observe the
+ # PRNG initialisation, which means that it can't have other tests running before
+ # it does.
+diff --git a/decrepit/CMakeLists.txt b/decrepit/CMakeLists.txt
+index ef95a6be0..70d2550d0 100644
+--- a/decrepit/CMakeLists.txt
++++ b/decrepit/CMakeLists.txt
+@@ -26,6 +26,12 @@ add_dependencies(decrepit global_target)
+ 
+ target_link_libraries(decrepit crypto ssl)
+ 
++install(TARGETS decrepit
++    EXPORT boringssl-targets
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)
++
+ add_executable(
+   decrepit_test
+ 
+diff --git a/ssl/CMakeLists.txt b/ssl/CMakeLists.txt
+index 0fb532eae..41a2c4624 100644
+--- a/ssl/CMakeLists.txt
++++ b/ssl/CMakeLists.txt
+@@ -45,6 +45,12 @@ add_dependencies(ssl global_target)
+ 
+ target_link_libraries(ssl crypto)
+ 
++install(TARGETS ssl
++    EXPORT boringssl-targets
++    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
++    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
++)
++
+ add_executable(
+   ssl_test
+ 


### PR DESCRIPTION
This is related to the discussion [here](https://github.com/litespeedtech/lsquic/issues/96#issuecomment-698598577) about OpenSSL. In a nutshell, I believe that BoringSSL should be linked with `find_package(OpenSSL REQUIRED)`, so that it can be interchanged with OpenSSL when supported.

BoringSSL is not meant to be installed on the system, but `CMAKE_PREFIX_PATH` allows to set a local path where `find_package` should look for packages before it looks on the system. I use that extensively in the project I co-maintain, MAVSDK, where we have a "superbuild" mode to build all our dependencies (see [here](https://github.com/mavlink/MAVSDK/tree/develop/third_party)).

Because the BoringSSL maintainers don't want to add a CMake install target (to not suggest that it should be installed on the system), I added a patch in the helper in `tools/install_boringssl`.

The README should show how to use it. I like this way (using `find_package`), because it allows to easily depend on the system libraries (which git submodules don't).

I would also use `find_package` for `zlib` and `libevent`, but first I would like the maintainers' opinion about this approach :innocent:.

EDIT: I did not try the Docker stuff in the README, which I probably break. Also, I probably break the `BUILD_SHARED_LIBS` expectations, but this PR is mainly to get your opinion, it can be improved if you want to go this way.