### PR TITLE
Add CMake install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ OPTION(LSQUIC_BIN "Compile example binaries that use the library" ON)
 OPTION(LSQUIC_TESTS "Compile library unit tests" ON)
 OPTION(LSQUIC_SHARED_LIB "Compile as shared librarry" OFF)
 
+INCLUDE(GNUInstallDirs)
+
 IF (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     # If using older glibc, need to link with -lrt.  See clock_getres(2).
     EXECUTE_PROCESS(
@@ -336,3 +338,10 @@ IF(SPHINX)
 ELSE()
     MESSAGE(STATUS "sphinx-build not found: docs won't be made")
 ENDIF()
+
+INSTALL(FILES
+    include/lsquic.h
+    include/lsquic_types.h
+    include/lsxpack_header.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lsquic
+)

--- a/src/liblsquic/CMakeLists.txt
+++ b/src/liblsquic/CMakeLists.txt
@@ -115,3 +115,9 @@ ELSE()
   add_library(lsquic STATIC ${lsquic_STAT_SRCS})
 ENDIF()
 
+install(TARGETS lsquic
+    EXPORT lsquic-targets
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+


### PR DESCRIPTION
This adds a CMake install target, such that something like:

```
cmake -DCMAKE_INSTALL_PREFIX=install -DBORINGSSL_DIR=$BORINGSSL -Bbuild -S.
cmake --build build --target install
```

Builds and installs liblsquic as follows:

```
% tree install
install
├── include
│   └── lsquic
│       ├── lsquic.h
│       ├── lsquic_types.h
│       └── lsxpack_header.h
└── lib
    └── liblsquic.a
```

I am using that on my (playground) setup, and thought I could share it. Feel free to just close that PR if that's not relevant for you :+1:.