### PR TITLE
GSO-Friendly Packet Memory

### DIFF
--- a/bin/test_common.c
+++ b/bin/test_common.c
@@ -2043,7 +2043,7 @@ pba_init (struct packout_buf_allocator *pba, unsigned max)
 
 
 void *
-pba_allocate (void *packout_buf_allocator, void *peer_ctx, lsquic_conn_get_ctx *conn_ctx, unsigned short size,
+pba_allocate (void *packout_buf_allocator, void *peer_ctx, lsquic_conn_ctx_t *conn_ctx, unsigned short size,
                                                                 char is_ipv6)
 {
     struct packout_buf_allocator *const pba = packout_buf_allocator;

--- a/bin/test_common.c
+++ b/bin/test_common.c
@@ -2043,7 +2043,7 @@ pba_init (struct packout_buf_allocator *pba, unsigned max)
 
 
 void *
-pba_allocate (void *packout_buf_allocator, void *peer_ctx, lsquic_conn_ctx_t *conn_ctx, unsigned short size,
+pba_allocate (void *packout_buf_allocator, void *peer_ctx, void *conn_ctx, unsigned short size,
                                                                 char is_ipv6)
 {
     struct packout_buf_allocator *const pba = packout_buf_allocator;

--- a/bin/test_common.c
+++ b/bin/test_common.c
@@ -2043,7 +2043,7 @@ pba_init (struct packout_buf_allocator *pba, unsigned max)
 
 
 void *
-pba_allocate (void *packout_buf_allocator, void *peer_ctx, unsigned short size,
+pba_allocate (void *packout_buf_allocator, void *peer_ctx, lsquic_conn_get_ctx *conn_ctx, unsigned short size,
                                                                 char is_ipv6)
 {
     struct packout_buf_allocator *const pba = packout_buf_allocator;

--- a/bin/test_common.h
+++ b/bin/test_common.h
@@ -115,7 +115,7 @@ void
 pba_init (struct packout_buf_allocator *, unsigned max);
 
 void *
-pba_allocate (void *packout_buf_allocator, void*, unsigned short, char);
+pba_allocate (void *packout_buf_allocator, void*, lsquic_conn_get_ctx *conn_ctx, unsigned short, char);
 
 void
 pba_release (void *packout_buf_allocator, void *, void *obj, char);

--- a/bin/test_common.h
+++ b/bin/test_common.h
@@ -111,6 +111,10 @@ struct packout_buf_allocator
     SLIST_HEAD(, packout_buf)   free_packout_bufs;
 };
 
+struct lsquic_conn_ctx {
+
+};
+
 void
 pba_init (struct packout_buf_allocator *, unsigned max);
 

--- a/bin/test_common.h
+++ b/bin/test_common.h
@@ -111,15 +111,11 @@ struct packout_buf_allocator
     SLIST_HEAD(, packout_buf)   free_packout_bufs;
 };
 
-struct lsquic_conn_ctx {
-
-};
-
 void
 pba_init (struct packout_buf_allocator *, unsigned max);
 
 void *
-pba_allocate (void *packout_buf_allocator, void*, lsquic_conn_ctx_t *conn_ctx, unsigned short, char);
+pba_allocate (void *packout_buf_allocator, void*, void *conn_ctx, unsigned short, char);
 
 void
 pba_release (void *packout_buf_allocator, void *, void *obj, char);

--- a/bin/test_common.h
+++ b/bin/test_common.h
@@ -115,7 +115,7 @@ void
 pba_init (struct packout_buf_allocator *, unsigned max);
 
 void *
-pba_allocate (void *packout_buf_allocator, void*, lsquic_conn_get_ctx *conn_ctx, unsigned short, char);
+pba_allocate (void *packout_buf_allocator, void*, lsquic_conn_ctx_t *conn_ctx, unsigned short, char);
 
 void
 pba_release (void *packout_buf_allocator, void *, void *obj, char);

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -2008,7 +2008,7 @@ Miscellaneous Types
 
     If not specified, malloc() and free() are used.
 
-    .. member:: void *  (*pmi_allocate) (void *pmi_ctx, void *peer_ctx, unsigned short sz, char is_ipv6)
+    .. member:: void *  (*pmi_allocate) (void *pmi_ctx, void *peer_ctx, lsquic_conn_get_ctx *conn_ctx, unsigned short sz, char is_ipv6)
 
         Allocate buffer for sending.
 

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -966,7 +966,8 @@ struct lsquic_out_spec
     const struct sockaddr *local_sa;
     const struct sockaddr *dest_sa;
     void                  *peer_ctx;
-    int                    ecn; /* Valid values are 0 - 3.  See RFC 3168 */
+    lsquic_conn_ctx_t     *conn_ctx;  /* will be NULL when sending out the first batch of handshake packets */
+    int                    ecn;       /* Valid values are 0 - 3.  See RFC 3168 */
 };
 
 /**

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -1035,7 +1035,7 @@ struct lsquic_packout_mem_if
     /**
      * Allocate buffer for sending.
      */
-    void *  (*pmi_allocate) (void *pmi_ctx, void *peer_ctx, unsigned short sz,
+    void *  (*pmi_allocate) (void *pmi_ctx, void *peer_ctx, lsquic_conn_ctx_t *, unsigned short sz,
                                                                 char is_ipv6);
     /**
      * This function is used to release the allocated buffer after it is

--- a/src/liblsquic/lsquic_conn.c
+++ b/src/liblsquic/lsquic_conn.c
@@ -205,14 +205,14 @@ lsquic_conn_push_stream (struct lsquic_conn *lconn, void *hset,
 lsquic_conn_ctx_t *
 lsquic_conn_get_ctx (const struct lsquic_conn *lconn)
 {
-    return lconn->cn_if->ci_get_ctx(lconn);
+    return lconn->conn_ctx;
 }
 
 
 void
 lsquic_conn_set_ctx (struct lsquic_conn *lconn, lsquic_conn_ctx_t *ctx)
 {
-    lconn->cn_if->ci_set_ctx(lconn, ctx);
+    lconn->conn_ctx = ctx;
 }
 
 

--- a/src/liblsquic/lsquic_conn.h
+++ b/src/liblsquic/lsquic_conn.h
@@ -178,12 +178,6 @@ struct conn_iface
     struct lsquic_engine *
     (*ci_get_engine) (struct lsquic_conn *);
 
-    struct lsquic_conn_ctx *
-    (*ci_get_ctx) (const struct lsquic_conn *);
-
-    void
-    (*ci_set_ctx) (struct lsquic_conn *, struct lsquic_conn_ctx *);
-
     void
     (*ci_make_stream) (struct lsquic_conn *);
 
@@ -318,6 +312,7 @@ struct conn_cid_elem
 struct lsquic_conn
 {
     void                        *cn_enc_session;
+    lsquic_conn_ctx_t           *conn_ctx;
     const struct enc_session_funcs_common
                                 *cn_esf_c;
     union {

--- a/src/liblsquic/lsquic_enc_sess_ietf.c
+++ b/src/liblsquic/lsquic_enc_sess_ietf.c
@@ -1973,7 +1973,7 @@ iquic_esf_encrypt_packet (enc_session_t *enc_session_p,
     dst_sz = lconn->cn_pf->pf_packout_size(lconn, packet_out);
     ipv6 = NP_IS_IPv6(packet_out->po_path);
     dst = enpub->enp_pmi->pmi_allocate(enpub->enp_pmi_ctx,
-                                packet_out->po_path->np_peer_ctx, dst_sz, ipv6);
+                                packet_out->po_path->np_peer_ctx, lsquic_conn_get_ctx(lconn), dst_sz, ipv6);
     if (!dst)
     {
         LSQ_DEBUG("could not allocate memory for outgoing packet of size %zd",

--- a/src/liblsquic/lsquic_enc_sess_ietf.c
+++ b/src/liblsquic/lsquic_enc_sess_ietf.c
@@ -1973,7 +1973,7 @@ iquic_esf_encrypt_packet (enc_session_t *enc_session_p,
     dst_sz = lconn->cn_pf->pf_packout_size(lconn, packet_out);
     ipv6 = NP_IS_IPv6(packet_out->po_path);
     dst = enpub->enp_pmi->pmi_allocate(enpub->enp_pmi_ctx,
-                                packet_out->po_path->np_peer_ctx, lsquic_conn_get_ctx(lconn), dst_sz, ipv6);
+                                packet_out->po_path->np_peer_ctx, lconn->conn_ctx, dst_sz, ipv6);
     if (!dst)
     {
         LSQ_DEBUG("could not allocate memory for outgoing packet of size %zd",

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -1955,7 +1955,7 @@ copy_packet (struct lsquic_engine *engine, struct lsquic_conn *conn,
     }
 
     packet_out->po_enc_data = engine->pub.enp_pmi->pmi_allocate(
-                    engine->pub.enp_pmi_ctx, packet_out->po_path->np_peer_ctx,
+                    engine->pub.enp_pmi_ctx, packet_out->po_path->np_peer_ctx, lsquic_conn_get_ctx(conn),
                     packet_out->po_data_sz, ipv6);
     if (!packet_out->po_enc_data)
     {

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -466,7 +466,7 @@ free_packet (void *ctx, void *conn_ctx, void *packet_data, char is_ipv6)
 
 
 static void *
-malloc_buf (void *ctx, void *conn_ctx, unsigned short size, char is_ipv6)
+malloc_buf (void *ctx, void *conn_ctx, lsquic_conn_ctx_t *conn_ctx, unsigned short size, char is_ipv6)
 {
     return malloc(size);
 }

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -466,7 +466,7 @@ free_packet (void *ctx, void *conn_ctx, void *packet_data, char is_ipv6)
 
 
 static void *
-malloc_buf (void *ctx, void *conn_ctx, lsquic_conn_ctx_t *conn_ctx, unsigned short size, char is_ipv6)
+malloc_buf (void *ctx, void *peer_ctx, lsquic_conn_ctx_t *conn_ctx, unsigned short size, char is_ipv6)
 {
     return malloc(size);
 }

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -1955,7 +1955,7 @@ copy_packet (struct lsquic_engine *engine, struct lsquic_conn *conn,
     }
 
     packet_out->po_enc_data = engine->pub.enp_pmi->pmi_allocate(
-                    engine->pub.enp_pmi_ctx, packet_out->po_path->np_peer_ctx, lsquic_conn_get_ctx(conn),
+                    engine->pub.enp_pmi_ctx, packet_out->po_path->np_peer_ctx, conn->conn_ctx,
                     packet_out->po_data_sz, ipv6);
     if (!packet_out->po_enc_data)
     {
@@ -2463,6 +2463,7 @@ send_packets_out (struct lsquic_engine *engine,
             batch->outs   [n].peer_ctx = packet_out->po_path->np_peer_ctx;
             batch->outs   [n].local_sa = NP_LOCAL_SA(packet_out->po_path);
             batch->outs   [n].dest_sa  = NP_PEER_SA(packet_out->po_path);
+            batch->outs   [n].conn_ctx = conn->conn_ctx;
             batch->conns  [n]          = conn;
         }
         *packet = packet_out;

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -376,7 +376,6 @@ struct ietf_full_conn
                                *ifc_enpub;
     const struct lsquic_engine_settings
                                *ifc_settings;
-    lsquic_conn_ctx_t          *ifc_conn_ctx;
     STAILQ_HEAD(, stream_id_to_ss)
                                 ifc_stream_ids_to_ss;
     lsquic_time_t               ifc_created;
@@ -1550,7 +1549,7 @@ lsquic_ietf_full_conn_server_new (struct lsquic_engine_public *enpub,
     conn->ifc_last_live_update = now;
 
     LSQ_DEBUG("Calling on_new_conn callback");
-    conn->ifc_conn_ctx = conn->ifc_enpub->enp_stream_if->on_new_conn(
+    conn->ifc_conn.conn_ctx = conn->ifc_enpub->enp_stream_if->on_new_conn(
                         conn->ifc_enpub->enp_stream_if_ctx, &conn->ifc_conn);
 
     if (0 != handshake_ok(&conn->ifc_conn))
@@ -2759,7 +2758,7 @@ ietf_full_conn_ci_client_call_on_new (struct lsquic_conn *lconn)
 {
     struct ietf_full_conn *conn = (struct ietf_full_conn *) lconn;
     assert(conn->ifc_flags & IFC_CREATED_OK);
-    conn->ifc_conn_ctx = conn->ifc_enpub->enp_stream_if->on_new_conn(
+    lconn->conn_ctx = conn->ifc_enpub->enp_stream_if->on_new_conn(
                                 conn->ifc_enpub->enp_stream_if_ctx, lconn);
 }
 
@@ -7904,27 +7903,11 @@ ietf_full_conn_ci_stateless_reset (struct lsquic_conn *lconn)
 }
 
 
-static struct lsquic_conn_ctx *
-ietf_full_conn_ci_get_ctx (const struct lsquic_conn *lconn)
-{
-    struct ietf_full_conn *const conn = (struct ietf_full_conn *) lconn;
-    return conn->ifc_conn_ctx;
-}
-
-
 static struct lsquic_engine *
 ietf_full_conn_ci_get_engine (struct lsquic_conn *lconn)
 {
     struct ietf_full_conn *conn = (struct ietf_full_conn *) lconn;
     return conn->ifc_enpub->enp_engine;
-}
-
-
-static void
-ietf_full_conn_ci_set_ctx (struct lsquic_conn *lconn, lsquic_conn_ctx_t *ctx)
-{
-    struct ietf_full_conn *const conn = (struct ietf_full_conn *) lconn;
-    conn->ifc_conn_ctx = ctx;
 }
 
 
@@ -8190,7 +8173,6 @@ ietf_full_conn_ci_count_garbage (struct lsquic_conn *lconn, size_t garbage_sz)
     .ci_destroy              =  ietf_full_conn_ci_destroy, \
     .ci_drain_time           =  ietf_full_conn_ci_drain_time, \
     .ci_drop_crypto_streams  =  ietf_full_conn_ci_drop_crypto_streams, \
-    .ci_get_ctx              =  ietf_full_conn_ci_get_ctx, \
     .ci_get_engine           =  ietf_full_conn_ci_get_engine, \
     .ci_get_log_cid          =  ietf_full_conn_ci_get_log_cid, \
     .ci_get_min_datagram_size=  ietf_full_conn_ci_get_min_datagram_size, \
@@ -8210,7 +8192,6 @@ ietf_full_conn_ci_count_garbage (struct lsquic_conn *lconn, size_t garbage_sz)
     .ci_record_addrs         =  ietf_full_conn_ci_record_addrs, \
     .ci_report_live          =  ietf_full_conn_ci_report_live, \
     .ci_retx_timeout         =  ietf_full_conn_ci_retx_timeout, \
-    .ci_set_ctx              =  ietf_full_conn_ci_set_ctx, \
     .ci_set_min_datagram_size=  ietf_full_conn_ci_set_min_datagram_size, \
     .ci_status               =  ietf_full_conn_ci_status, \
     .ci_stateless_reset      =  ietf_full_conn_ci_stateless_reset, \

--- a/src/liblsquic/lsquic_handshake.c
+++ b/src/liblsquic/lsquic_handshake.c
@@ -3746,7 +3746,7 @@ gquic_encrypt_packet (enc_session_t *enc_session_p,
         return ENCPA_BADCRYPT;  /* To cause connection to close */
     ipv6 = NP_IS_IPv6(packet_out->po_path);
     buf = enpub->enp_pmi->pmi_allocate(enpub->enp_pmi_ctx,
-                                packet_out->po_path->np_peer_ctx, bufsz, ipv6);
+                                packet_out->po_path->np_peer_ctx, lsquic_conn_get_ctx(lconn), bufsz, ipv6);
     if (!buf)
     {
         LSQ_DEBUG("could not allocate memory for outgoing packet of size %zd",
@@ -3944,7 +3944,7 @@ gquic2_esf_encrypt_packet (enc_session_t *enc_session_p,
     dst_sz = lconn->cn_pf->pf_packout_size(lconn, packet_out);
     ipv6 = NP_IS_IPv6(packet_out->po_path);
     dst = enpub->enp_pmi->pmi_allocate(enpub->enp_pmi_ctx,
-                                packet_out->po_path->np_peer_ctx, dst_sz, ipv6);
+                                packet_out->po_path->np_peer_ctx, lsquic_conn_get_ctx(lconn), dst_sz, ipv6);
     if (!dst)
     {
         LSQ_DEBUG("could not allocate memory for outgoing packet of size %zd",

--- a/src/liblsquic/lsquic_handshake.c
+++ b/src/liblsquic/lsquic_handshake.c
@@ -3746,7 +3746,7 @@ gquic_encrypt_packet (enc_session_t *enc_session_p,
         return ENCPA_BADCRYPT;  /* To cause connection to close */
     ipv6 = NP_IS_IPv6(packet_out->po_path);
     buf = enpub->enp_pmi->pmi_allocate(enpub->enp_pmi_ctx,
-                                packet_out->po_path->np_peer_ctx, lsquic_conn_get_ctx(lconn), bufsz, ipv6);
+                                packet_out->po_path->np_peer_ctx, lconn->conn_ctx, bufsz, ipv6);
     if (!buf)
     {
         LSQ_DEBUG("could not allocate memory for outgoing packet of size %zd",
@@ -3944,7 +3944,7 @@ gquic2_esf_encrypt_packet (enc_session_t *enc_session_p,
     dst_sz = lconn->cn_pf->pf_packout_size(lconn, packet_out);
     ipv6 = NP_IS_IPv6(packet_out->po_path);
     dst = enpub->enp_pmi->pmi_allocate(enpub->enp_pmi_ctx,
-                                packet_out->po_path->np_peer_ctx, lsquic_conn_get_ctx(lconn), dst_sz, ipv6);
+                                packet_out->po_path->np_peer_ctx, lconn->conn_ctx, dst_sz, ipv6);
     if (!dst)
     {
         LSQ_DEBUG("could not allocate memory for outgoing packet of size %zd",


### PR DESCRIPTION
> this trivial patch enables the batching of packets out into a persistent buffer per connection, for cleaner more efficient GSO.
> 
> currently there is no way to relate the peer_ctx back to a connection inside the pmi_allocate callback, so the best you can do is a pool of packet buffers. This can lead to ~40+ unique packet buffers being passed via sendmsg into the kernel and just as many unique copies.
> 
> or one could construct a contiguous buffer of all packets for GSO within the ea_packets_out at the expense of all those copies.
> 
> and all is complicated further by using io_uring given the asynchronous sendmsg completions.
> 
> this patch relies on the assumption of sequence. That for a given connection, the sequence in which packet buffers are requested from pmi_allocate matches the order in which they are passed to ea_packets_out.
> 
> now all you need to do is group packets by connection in your ea_packets_out callback, then calculate the contiguous buffer they constitute into a new struct iov_vec and pass it into sendmsg.

accidentally deleted my branch lol. So here's the PR again, including all the changes we discussed.