### PR TITLE
Support get_ssl_ctx callback for client

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -317,7 +317,7 @@ Other required engine callbacks are a set of stream and connection callbacks tha
     /* --- 8< --- snip --- 8< --- */
     .ea_stream_if       = &stream_callbacks,
     .ea_stream_if_ctx   = &some_context,
-    .ea_get_ssl_ctx     = get_ssl_ctx,  /* Server only */
+    .ea_get_ssl_ctx     = get_ssl_ctx,  
   };
 
 

--- a/src/liblsquic/lsquic_enc_sess.h
+++ b/src/liblsquic/lsquic_enc_sess.h
@@ -264,7 +264,7 @@ struct enc_session_funcs_iquic
                            const struct ver_neg *, void *(crypto_streams)[4],
                            const struct crypto_stream_if *,
                            const unsigned char *, size_t,
-                           struct lsquic_alarmset *, unsigned);
+                           struct lsquic_alarmset *, unsigned, void*);
 
     void
     (*esfi_destroy) (enc_session_t *);

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -1747,7 +1747,7 @@ lsquic_engine_connect (lsquic_engine_t *engine, enum lsquic_version version,
     if (versions & LSQUIC_IETF_VERSIONS)
         conn = lsquic_ietf_full_conn_client_new(&engine->pub, versions,
                     flags, hostname, base_plpmtu,
-                    is_ipv4, sess_resume, sess_resume_len, token, token_sz);
+                    is_ipv4, sess_resume, sess_resume_len, token, token_sz, peer_ctx);
     else
         conn = lsquic_gquic_full_conn_client_new(&engine->pub, versions,
                             flags, hostname, base_plpmtu, is_ipv4,

--- a/src/liblsquic/lsquic_full_conn.h
+++ b/src/liblsquic/lsquic_full_conn.h
@@ -19,7 +19,7 @@ lsquic_ietf_full_conn_client_new (struct lsquic_engine_public *,
                unsigned flags /* Only FC_SERVER and FC_HTTP */,
            const char *hostname, unsigned short base_plpmtu, int is_ipv4,
            const unsigned char *sess_resume, size_t,
-           const unsigned char *token, size_t);
+           const unsigned char *token, size_t, void* peer_ctx);
 
 typedef struct lsquic_conn *
 (*server_conn_ctor_f) (struct lsquic_engine_public *,

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -1303,7 +1303,7 @@ lsquic_ietf_full_conn_client_new (struct lsquic_engine_public *enpub,
            unsigned versions, unsigned flags,
            const char *hostname, unsigned short base_plpmtu, int is_ipv4,
            const unsigned char *sess_resume, size_t sess_resume_sz,
-           const unsigned char *token, size_t token_sz)
+           const unsigned char *token, size_t token_sz, void* peer_ctx)
 {
     const struct transport_params *params;
     const struct enc_session_funcs_iquic *esfi;
@@ -1397,7 +1397,7 @@ lsquic_ietf_full_conn_client_new (struct lsquic_engine_public *enpub,
                 &conn->ifc_u.cli.ifcli_ver_neg,
                 (void **) conn->ifc_u.cli.crypto_streams, &crypto_stream_if,
                 sess_resume, sess_resume_sz, &conn->ifc_alset,
-                conn->ifc_max_streams_in[SD_UNI]);
+                conn->ifc_max_streams_in[SD_UNI], peer_ctx);
     if (!conn->ifc_conn.cn_enc_session)
         goto err2;
 


### PR DESCRIPTION
Extending the get_sst_ctx callback to support setting SSL contexts on the client side similar to the server implementation.