### PR TITLE
Update docs

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -55,6 +55,12 @@ Grab a page from your server:
 You can play with various options, of which there are many.  Use
 the ``-h`` command-line flag to see them.
 
+More about LSQUIC
+-----------------
+
+You may be also interested in this presentation_ about LSQUIC.
+Slides are available `here <https://github.com/dtikhonov/talks/tree/master/netdev-0x14>`_.
+
 Next steps
 ----------
 
@@ -69,3 +75,4 @@ the :doc:`apiref`.
 .. _`ls-qpack`: https://github.com/litespeedtech/ls-qpack
 .. _libevent: https://libevent.org/
 .. _README: https://github.com/litespeedtech/lsquic/blob/master/README.md
+.. _presentation: https://www.youtube.com/watch?v=kDwyGNsQXds

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -2,6 +2,8 @@
 Tutorial
 ********
 
+Code for this tutorial is available on `GitHub <https://github.com/dtikhonov/lsquic-tutorial>`_.
+
 .. highlight:: c
 
 Introduction

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -151,6 +151,9 @@ Receiving Packets
 UDP datagrams are passed to the engine using the :func:`lsquic_engine_packet_in()` function.  This is the only way to do so.
 A pointer to the UDP payload is passed along with the size of the payload.
 Local and peer socket addresses are passed in as well.
+The local one is required for two reasons.
+Firstly it becomes source address on outgoing packets.
+Secondly QUIC uses it to send special frames to validate path.
 The void "peer ctx" pointer is associated with the peer address.  It gets passed to the function that sends outgoing packets and to a few other callbacks.  In a standard setup, this is most likely the socket file descriptor, but it could be pointing to something else.
 The  ECN value is in the range of 0 through 3, as in RFC 3168.
 


### PR DESCRIPTION
Mentioning about lsquic tutorial code or presentation from Netdev can be so valuable for newcomers. I haven't found any references to them in docs so far so I have made this small PR. I have also copied from Netdev slides explanation of local address in one function but honestly I don't still get why we also pass local address to `lsquic_engine_connect`. 