### PR TITLE
Notification callback on CONNECTION_CLOSE frame

### DIFF
--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -221,6 +221,16 @@ struct lsquic_stream_if {
      * just one direction in IETF QUIC.
      */
     void (*on_reset)    (lsquic_stream_t *s, lsquic_stream_ctx_t *h, int how);
+    /**
+     * Optional callback is called when a CONNECTION_CLOSE frame is received.
+     * This allows the application to log low-level diagnostic information about
+     * errors received with the CONNECTION_CLOSE frame. If app_error is -1 then
+     * it is considered unknown if this is an app_error or not.
+     */
+#define LSQUIC_SUPPORTS_CONNCLOSEFRAME_CALLBACK
+    void (*on_conncloseframe_received)(lsquic_conn_t *c,
+                                       int app_error, uint64_t error_code,
+                                       const char *reason, int reason_len);
 };
 
 struct ssl_ctx_st;

--- a/src/liblsquic/lsquic_full_conn.c
+++ b/src/liblsquic/lsquic_full_conn.c
@@ -2098,6 +2098,9 @@ process_connection_close_frame (struct full_conn *conn, lsquic_packet_in_t *pack
                             (int) reason_len, (const char *) p + reason_off);
     LSQ_INFO("Received CONNECTION_CLOSE frame (code: %"PRIu64"; reason: %.*s)",
                 error_code, (int) reason_len, (const char *) p + reason_off);
+    if (conn->fc_stream_ifs[STREAM_IF_STD].stream_if->on_conncloseframe_received)
+        conn->fc_stream_ifs[STREAM_IF_STD].stream_if->on_conncloseframe_received(
+            &conn->fc_conn, -1, error_code, (const char *) p + reason_off, reason_len);
     conn->fc_flags |= FC_RECV_CLOSE;
     if (!(conn->fc_flags & FC_CLOSING))
     {

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -5960,6 +5960,9 @@ process_connection_close_frame (struct ietf_full_conn *conn,
         LSQ_INFO("Received CONNECTION_CLOSE frame (%s-level code: %"PRIu64"; "
             "reason: %.*s)", app_error ? "application" : "transport",
                 error_code, (int) reason_len, (const char *) p + reason_off);
+    if (conn->ifc_enpub->enp_stream_if->on_conncloseframe_received)
+        conn->ifc_enpub->enp_stream_if->on_conncloseframe_received(
+            &conn->ifc_conn, app_error, error_code, (const char *) p + reason_off, reason_len);
     conn->ifc_flags |= IFC_RECV_CLOSE;
     if (!(conn->ifc_flags & IFC_CLOSING))
     {


### PR DESCRIPTION
Support new lsquic_stream_if callback on_conncloseframe_received() to notify application of CONNECTION_CLOSE frame
