### PR TITLE
Make other quic library which scid length is larger than 16B can update to lsquic

### DIFF
--- a/src/liblsquic/lsquic_handshake.c
+++ b/src/liblsquic/lsquic_handshake.c
@@ -1143,15 +1143,15 @@ static int parse_hs_data (struct lsquic_enc_session *enc_session, uint32_t tag,
         break;
 
     case QTAG_SCID:
-        if (len != SCID_LENGTH)
+        if (len < SCID_LENGTH)
             return -1;
         if (is_client)
         {
-            memcpy(enc_session->info->sscid, val, len);
+            memcpy(enc_session->info->sscid, val, SCID_LENGTH);
         }
         else
         {
-            memcpy(hs_ctx->scid, val, len);
+            memcpy(hs_ctx->scid, val, SCID_LENGTH);
             hs_ctx->set |= HSET_SCID;
         }
         ESHIST_APPEND(enc_session, ESHE_SET_SCID);


### PR DESCRIPTION
Problem:
We are using other quic library which scid length is larger than 16B, and we want to change it with lsquic. But I found that lots of client which create new connection with SICD( means 0RTT) will be PRST by lsquic, and cannot establish connection.

Reason:
Lsquic send PRST but not REJ to those client which create with scid(means 0RTT) but  scid length not equal 16B, and these client won't retry, which means that these client will never connect with new server with quic. 

Solution:
If SCID length is larger than 16B, lsquic truncate it, and then determine_rtt will return 1RTT, which means send REJ to client.

