### PR TITLE
Fix: connection may not be closed timely when CONNECTION_CLOSE frame in

### DIFF
--- a/src/liblsquic/lsquic_full_conn.c
+++ b/src/liblsquic/lsquic_full_conn.c
@@ -3594,23 +3594,16 @@ full_conn_ci_tick (lsquic_conn_t *lconn, lsquic_time_t now)
          * packets scheduled to send, or silent close flag is not set.
          */
         conn->fc_flags |= FC_TICK_CLOSE;
-        if ((conn->fc_flags & FC_RECV_CLOSE) &&
-                !lsquic_send_ctl_can_send(&conn->fc_send_ctl))
-        {
-            LSQ_DEBUG("CONNECTION_CLOSE received, and lsquic_send_ctl_can_send false,"
-                      " close full conn immediately.");
-            tick |= TICK_CLOSE;
-        }
-        else if ((conn->fc_flags & FC_RECV_CLOSE) ||
+        tick |= TICK_CLOSE;
+        if ((conn->fc_flags & FC_RECV_CLOSE) ||
                 0 != lsquic_send_ctl_n_scheduled(&conn->fc_send_ctl) ||
                                         !conn->fc_settings->es_silent_close)
         {
             RETURN_IF_OUT_OF_PACKETS();
             generate_connection_close_packet(conn);
-            tick |= TICK_SEND|TICK_CLOSE;
+            tick |= TICK_SEND;
         }
-        else
-            tick |= TICK_CLOSE;
+
         goto end;
     }
 

--- a/src/liblsquic/lsquic_full_conn.c
+++ b/src/liblsquic/lsquic_full_conn.c
@@ -3499,7 +3499,7 @@ full_conn_ci_tick (lsquic_conn_t *lconn, lsquic_time_t now)
          * more than 1 packet over CWND.
          */
         tick |= TICK_SEND;
-        goto end;
+        goto end_write;
     }
 
     /* Try to fit any of the following three frames -- STOP_WAITING,
@@ -3587,7 +3587,6 @@ full_conn_ci_tick (lsquic_conn_t *lconn, lsquic_time_t now)
   skip_write:
     if ((conn->fc_flags & FC_CLOSING) && conn_ok_to_close(conn))
     {
-        RETURN_IF_OUT_OF_PACKETS();
         LSQ_DEBUG("connection is OK to close");
         /* This is normal termination sequence.
          *
@@ -3595,10 +3594,18 @@ full_conn_ci_tick (lsquic_conn_t *lconn, lsquic_time_t now)
          * packets scheduled to send, or silent close flag is not set.
          */
         conn->fc_flags |= FC_TICK_CLOSE;
-        if ((conn->fc_flags & FC_RECV_CLOSE) ||
+        if ((conn->fc_flags & FC_RECV_CLOSE) &&
+                !lsquic_send_ctl_can_send(&conn->fc_send_ctl))
+        {
+            LSQ_DEBUG("CONNECTION_CLOSE received, and lsquic_send_ctl_can_send false,"
+                      " close full conn immediately.");
+            tick |= TICK_CLOSE;
+        }
+        else if ((conn->fc_flags & FC_RECV_CLOSE) ||
                 0 != lsquic_send_ctl_n_scheduled(&conn->fc_send_ctl) ||
                                         !conn->fc_settings->es_silent_close)
         {
+            RETURN_IF_OUT_OF_PACKETS();
             generate_connection_close_packet(conn);
             tick |= TICK_SEND|TICK_CLOSE;
         }

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -8344,14 +8344,8 @@ ietf_full_conn_ci_tick (struct lsquic_conn *lconn, lsquic_time_t now)
     {
         LSQ_DEBUG("connection is OK to close");
         conn->ifc_flags |= IFC_TICK_CLOSE;
-        if ((conn->ifc_flags & IFC_RECV_CLOSE) &&
-                !lsquic_send_ctl_can_send(&conn->ifc_send_ctl))
-        {
-            LSQ_DEBUG("CONNECTION_CLOSE received, and lsquic_send_ctl_can_send false,"
-                      " close full conn immediately.");
-            tick |= TICK_CLOSE;
-        }
-        else if (!(conn->ifc_mflags & MF_CONN_CLOSE_PACK)
+        tick |= TICK_CLOSE;
+        if (!(conn->ifc_mflags & MF_CONN_CLOSE_PACK)
             /* Generate CONNECTION_CLOSE frame if:
              *     ... this is a client and handshake was successful;
              */
@@ -8375,10 +8369,9 @@ ietf_full_conn_ci_tick (struct lsquic_conn *lconn, lsquic_time_t now)
         {
             RETURN_IF_OUT_OF_PACKETS();
             generate_connection_close_packet(conn);
-            tick |= TICK_SEND|TICK_CLOSE;
+            tick |= TICK_SEND;
         }
-        else
-            tick |= TICK_CLOSE;
+
         goto end;
     }
 


### PR DESCRIPTION
Full connection should be closed after CONNECTION_CLOSE frame in.
Issue: https://github.com/litespeedtech/lsquic/issues/281
