### PR TITLE
Tick connection on want_datagram_write

### DIFF
--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -2900,8 +2900,11 @@ ietf_full_conn_ci_want_datagram_write (struct lsquic_conn *lconn, int is_want)
     if (conn->ifc_flags & IFC_DATAGRAMS)
     {
         old = !!(conn->ifc_mflags & MF_WANT_DATAGRAM_WRITE);
-        if (is_want)
+        if (is_want) {
             conn->ifc_mflags |= MF_WANT_DATAGRAM_WRITE;
+            lsquic_engine_add_conn_to_tickable(conn->ifc_enpub,
+                                                            &conn->ifc_conn);
+        }
         else
             conn->ifc_mflags &= ~MF_WANT_DATAGRAM_WRITE;
         LSQ_DEBUG("turn %s \"want datagram write\" flag",

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -2902,7 +2902,8 @@ ietf_full_conn_ci_want_datagram_write (struct lsquic_conn *lconn, int is_want)
         old = !!(conn->ifc_mflags & MF_WANT_DATAGRAM_WRITE);
         if (is_want) {
             conn->ifc_mflags |= MF_WANT_DATAGRAM_WRITE;
-            lsquic_engine_add_conn_to_tickable(conn->ifc_enpub,
+            if (lsquic_send_ctl_can_send (&conn->ifc_send_ctl))
+                lsquic_engine_add_conn_to_tickable(conn->ifc_enpub,
                                                             &conn->ifc_conn);
         }
         else


### PR DESCRIPTION
I've been experimenting with lsquic's DATAGRAM support recently and hit a snag. In an application that is sending only DATAGRAM frames (no streams), I found that calling [lsquic_conn_want_datagram_write](https://lsquic.readthedocs.io/en/latest/apiref.html#c.lsquic_conn_want_datagram_write) did not result in lsquic raising an [on_dg_write](https://lsquic.readthedocs.io/en/latest/apiref.html#c.lsquic_stream_if.on_dg_write) callback to my application when I next tried to process the connection(s).

I found that if I had DATAGRAM frames ready to transmit immediately when the handshake completed, then the library worked and issued me those callbacks. However, if the handshake completed before any data was ready to be sent, then I could not send any DATAGRAM frames at all.

This pull request is how I managed to fix it for my application. Is this the correct way of doing this, or have I misunderstood something about the library interface?