### PR TITLE
update boringssl version info to support h3

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ You may need to install pre-requisites like zlib and libevent.
 2. Use specific BoringSSL version
 
 ```
-git checkout a2278d4d2cabe73f6663e3299ea7808edfa306b9
+git checkout a9670a8b476470e6f874fef3554e8059683e1413
 ```
 
 3. Compile the library

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -89,7 +89,7 @@ enum lsquic_version
 };
 
 /**
- * We currently support versions 43, 46, 50, Draft-27, Draft-29, Draft-34,
+ * We currently support versions 43, 46, 50, Draft-27, Draft-29,
  * and IETF QUIC v1.
  * @see lsquic_version
  */


### PR DESCRIPTION
RFC9001: QUIC transport parameters are carried in a TLS extension.
Different versions of QUIC might define a different method for negotiating transport configuration.

h3: quic_transport_parameters(0x39)

REF ISSUE: https://github.com/litespeedtech/lsquic/issues/345