### PR TITLE
m) fix: handshake may failed if client send too many early data

### DIFF
--- a/src/liblsquic/lsquic_mini_conn.c
+++ b/src/liblsquic/lsquic_mini_conn.c
@@ -1853,8 +1853,10 @@ mini_conn_ci_packet_in (struct lsquic_conn *lconn,
         process_deferred_packets(mc);
     }
     else
-        LSQ_DEBUG("won't defer more than %u packets: drop",
-                                                MINI_CONN_MAX_DEFERRED);
+    {
+        process_packet(mc, packet_in);
+        process_deferred_packets(mc);
+    }
 }
 
 


### PR DESCRIPTION
#Reproduce
step1: PC1 quic client request normally and save 0rtt resumption info to file quic_0rtt.info
step2: PC2 quic client request with large early data(>10pkts,  20KB) with quic_0rtt.info

expect: step2 handshake successful with 1RTT
result: step2 handshake failed

cause： lsquic drop all new packets, include Full CHLO, when mc_n_deferred >= MINI_CONN_MAX_DEFERRED(10).