### PR TITLE
Fix consistency in use of Perl.

### DIFF
--- a/src/liblsquic/CMakeLists.txt
+++ b/src/liblsquic/CMakeLists.txt
@@ -108,7 +108,7 @@ ENDIF()
 
 ADD_CUSTOM_COMMAND(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lsquic_versions_to_string.c
-    COMMAND ${PERL}
+    COMMAND ${PERL_EXECUTABLE}
     ARGS ${CMAKE_CURRENT_SOURCE_DIR}/gen-verstrs.pl ${CMAKE_CURRENT_SOURCE_DIR}/../../include/lsquic.h ${CMAKE_CURRENT_BINARY_DIR}/lsquic_versions_to_string.c
     DEPENDS ./gen-verstrs.pl ${CMAKE_CURRENT_SOURCE_DIR}/../../include/lsquic.h
 )


### PR DESCRIPTION
FindPerl.cmake populates PERL_EXECUTABLE.

Corresponding fix also required in ls-qpack: https://github.com/litespeedtech/ls-qpack/pull/42

Found when submitting lsquic to vcpkg.