### PR TITLE
Fix sign comparison warning, which broke 32-bit builds.

### DIFF
--- a/src/liblsquic/lsquic_rechist.c
+++ b/src/liblsquic/lsquic_rechist.c
@@ -318,10 +318,10 @@ lsquic_rechist_received (lsquic_rechist_t *rechist, lsquic_packno_t packno,
     rechist->rh_elems[idx].re_low   = packno;
     rechist->rh_elems[idx].re_count = 1;
     rechist->rh_elems[idx].re_next  = next_idx;
-    if (next_idx == rechist->rh_head)
+    if (next_idx == (ptrdiff_t)rechist->rh_head)
         rechist->rh_head = idx;
     else
-        rechist->rh_elems[prev_idx].re_next  = idx;
+        rechist->rh_elems[prev_idx].re_next = idx;
 
     rechist_sanity_check(rechist);
     return REC_ST_OK;


### PR DESCRIPTION
This seems like the correct cast to make here: rh_head likely to be in the range of next_idx (ptrdiff_t) while next_idx might be negative and thus meaningless if cast to unsigned.

This causes a warning on most platforms and had broken the 32-bit Windows build (because of treating warnings as errors) - see https://github.com/microsoft/vcpkg/pull/24310#issuecomment-1112710573 

This PR assumes that 32-bit windows support is not intentionally omitted, see https://github.com/litespeedtech/lsquic/issues/382