### PR TITLE
Add back vc_compat.h header install.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,3 +336,10 @@ INSTALL(FILES
     include/lsxpack_header.h
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lsquic
 )
+
+if(WIN32)
+    install(FILES
+        wincompat/vc_compat.h
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/lsquic
+    )
+endif()


### PR DESCRIPTION
Windows installs are broken without it. Alternative is to inline the important parts
in lsquic.h which is probably better.

For some reason this was removed in the 3.1.0 release commit, my earlier PR's had it. ( see https://github.com/litespeedtech/lsquic/commit/a74702c630e108125e71898398737baec8f02238#comments )