### PR TITLE
Test case and fix for lsquic rechist list problem

### DIFF
--- a/src/liblsquic/lsquic_rechist.c
+++ b/src/liblsquic/lsquic_rechist.c
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
+#include <inttypes.h>
 
 #include "lsquic_int_types.h"
 #include "lsquic_rechist.h"
@@ -57,6 +59,49 @@ rechist_free_elem (struct lsquic_rechist *rechist, unsigned idx)
 
 #define RE_HIGH(el_) ((el_)->re_low + (el_)->re_count - 1)
 
+#if LSQUIC_TEST
+static void
+rechist_dump_elem(struct rechist_elem *el)
+{
+    fprintf(stderr,"[%"PRIu64"-%"PRIu64"]", RE_HIGH(el), el->re_low);
+}
+
+#ifdef __GNUC__
+__attribute__((unused))
+#endif
+static void
+rechist_dump(struct lsquic_rechist *rechist)
+{
+    fprintf(stderr,
+            "%p: cutoff %"PRIu64" l. acked %"PRIu64" masks %u alloced %u used %u max ranges %u head %u\n",
+            rechist,
+            rechist->rh_cutoff, 
+            rechist->rh_largest_acked_received,
+            rechist->rh_n_masks,
+            rechist->rh_n_alloced,
+            rechist->rh_n_used,
+            rechist->rh_max_ranges,
+            rechist->rh_head);
+
+    if (rechist->rh_n_used)
+    {
+        int idx = rechist->rh_head;
+        fprintf(stderr, " ");
+        unsigned n_elems = 0;
+        while (n_elems < rechist->rh_n_used)
+        {
+            ++n_elems;
+            struct rechist_elem *el =  &rechist->rh_elems[idx];
+            fprintf(stderr, " (%u)", idx); 
+            rechist_dump_elem(el);            
+            if (el->re_next == UINT_MAX)
+                break;
+            idx = el->re_next;
+        }
+        fprintf(stderr, "\n");
+    }
+}
+#endif /* LSQUIC_TEST */
 
 static unsigned
 find_free_slot (uintptr_t slots)
@@ -201,6 +246,9 @@ rechist_test_sanity (const struct lsquic_rechist *rechist)
         {
             ++n_elems;
             idx = el - rechist->rh_elems;
+            if (n_elems > rechist->rh_n_alloced
+                || idx >=  rechist->rh_n_alloced)
+                break;
             masks[idx >> LOG2_BITS] |= 1ull << (idx & ((1u << LOG2_BITS) - 1));
             if (el->re_next != UINT_MAX)
                 el = &rechist->rh_elems[el->re_next];
@@ -215,8 +263,7 @@ rechist_test_sanity (const struct lsquic_rechist *rechist)
     free(masks);
 }
 #define rechist_sanity_check(rechist_) do {                         \
-    if (0 == ++(rechist_)->rh_n_ops % 127)                          \
-        rechist_test_sanity(rechist_);                              \
+    rechist_test_sanity(rechist_);                              \
 } while (0)
 #else
 #define rechist_sanity_check(rechist)

--- a/src/liblsquic/lsquic_rechist.c
+++ b/src/liblsquic/lsquic_rechist.c
@@ -219,6 +219,8 @@ rechist_alloc_elem (struct lsquic_rechist *rechist)
     idx = find_free_slot(*mask);
     *mask |= 1ull << idx;
     ++rechist->rh_n_used;
+    /*Note that re_next is invalid at this point, caller must set it */
+
     return idx + i * BITS_PER_MASK;
 }
 
@@ -278,7 +280,7 @@ lsquic_rechist_received (lsquic_rechist_t *rechist, lsquic_packno_t packno,
     ptrdiff_t next_idx, prev_idx;
     int idx;
 
-    if (rechist->rh_n_alloced == 0)
+    if (rechist->rh_n_used == 0)
         goto first_elem;
 
     if (packno < rechist->rh_cutoff)

--- a/src/liblsquic/lsquic_rechist.h
+++ b/src/liblsquic/lsquic_rechist.h
@@ -39,9 +39,6 @@ struct lsquic_rechist {
         struct lsquic_packno_range      range;
         unsigned                        next;
     }                               rh_iter;
-#if LSQUIC_TEST
-    unsigned                        rh_n_ops;
-#endif
 };
 
 typedef struct lsquic_rechist lsquic_rechist_t;


### PR DESCRIPTION
Added test case produces a corrupt rechist. The rechist grows and then is
emptied, then a rechist is produced that is nominally empty (rh_n_used == 0)
but has a circular list in rh_elems.

lsquic_rechist_received: insert before done
0x7ffe65ce75a0: cutoff 9 l. acked 12087061905995 masks 1 alloced 4 used 1 max ranges 0 head 0
  (0)[9-9] (0)[9-9] (0)[9-9] (0)[9-9] (0)[9-9] (0)[9-9] (0)[9-9]
test_rechist: /tmp/lsquic/src/liblsquic/lsquic_rechist.c:272: rechist_test_sanity: Assertion `rechist->rh_n_used == n_elems' failed.