### PR TITLE
Remove redundant include

### DIFF
--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -86,7 +86,6 @@
 #include "lsquic_handshake.h"
 #include "lsquic_crand.h"
 #include "lsquic_ietf.h"
-#include "lsquic_handshake.h"
 
 #define LSQUIC_LOGGER_MODULE LSQLM_ENGINE
 #include "lsquic_logger.h"


### PR DESCRIPTION
`lsquic_handshake.h` is included twice in `lsquic_engine.c`.