### PR TITLE
[fix] assertion failure if poison packet was acked

### DIFF
--- a/src/liblsquic/lsquic_full_conn.c
+++ b/src/liblsquic/lsquic_full_conn.c
@@ -3411,6 +3411,8 @@ full_conn_ci_tick (lsquic_conn_t *lconn, lsquic_time_t now)
     ++conn->fc_stats.n_ticks;
 #endif
 
+    CLOSE_IF_NECESSARY();
+
     if (LSQ_LOG_ENABLED(LSQ_LOG_DEBUG)
         && conn->fc_mem_logged_last + 1000000 <= now)
     {

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -8201,6 +8201,8 @@ ietf_full_conn_ci_tick (struct lsquic_conn *lconn, lsquic_time_t now)
 
     CONN_STATS(n_ticks, 1);
 
+    CLOSE_IF_NECESSARY();
+
     if (conn->ifc_flags & IFC_HAVE_SAVED_ACK)
     {
         (void) /* If there is an error, we'll fail shortly */


### PR DESCRIPTION
Description:
- Error may occur while processing ack frame, e.g. poison packet was acked by hostile attack. and then conn is supposed to be aborted, shortly but not immediately;
- if ack frame processing failed while calling lsquic_engine_packet_in, and IFC_HAVE_SAVED_ACK had been set, then saved ack frame will be processed while ticking connection before it is aborted, that may lead to assert failure;

Solution:
- close connection if neccessary before processing ack while ci_tick.