### PR TITLE
link fix when using lsquic in a cpp project

### DIFF
--- a/src/liblsquic/lsquic_hash.h
+++ b/src/liblsquic/lsquic_hash.h
@@ -6,6 +6,10 @@
 #ifndef LSQUIC_HASH_H
 #define LSQUIC_HASH_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct lsquic_hash;
 
 struct lsquic_hash_elem
@@ -58,4 +62,9 @@ lsquic_hash_count (struct lsquic_hash *);
 
 size_t
 lsquic_hash_mem_used (const struct lsquic_hash *);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif


### PR DESCRIPTION
Hi,

I experienced problems when trying to link lsquic with a cpp project.
Adding this extern "C" fixes the issue.