### PR TITLE
m) Fix: ietf connection maybe abort if ack for hsk lost

### DIFF
--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -1886,7 +1886,7 @@ generate_ack_frame_for_pns (struct ietf_full_conn *conn,
             &conn->ifc_rechist[pns], now, &has_missing, &packet_out->po_ack2ed,
             ecn_counts);
     if (w < 0) {
-        ABORT_ERROR("generating ACK frame failed: %d", errno);
+        ABORT_ERROR("%s generating ACK frame failed: %d", lsquic_pns2str[pns], errno);
         return -1;
     }
     CONN_STATS(out.acks, 1);

--- a/src/liblsquic/lsquic_send_ctl.c
+++ b/src/liblsquic/lsquic_send_ctl.c
@@ -3424,6 +3424,8 @@ lsquic_send_ctl_empty_pns (struct lsquic_send_ctl *ctl, enum packnum_space pns)
 
     lsquic_alarmset_unset(ctl->sc_alset, AL_RETX_INIT + pns);
 
+    ctl->sc_flags &= ~(SC_LOST_ACK_INIT << pns);
+
     LSQ_DEBUG("emptied %s, destroyed %u packet%.*s", lsquic_pns2str[pns],
         count, count != 1, "s");
 }


### PR DESCRIPTION
1) After handshake done, handshake packets should not be sent or received.
2) IFC_ACK_QUED_HSK will be cancelled from conn->ifc_flags after handshake done, but it maybe set again if ACKs for handshake lost(Function: should_generate_ack).