### PR TITLE
m) Fix: packet_in pool memory leak

### DIFF
--- a/src/liblsquic/lsquic_enc_sess_ietf.c
+++ b/src/liblsquic/lsquic_enc_sess_ietf.c
@@ -2243,7 +2243,16 @@ iquic_esf_decrypt_packet (enc_session_t *enc_session_p,
     size_t out_sz;
     enum dec_packin dec_packin;
     int s;
-    const size_t dst_sz = packet_in->pi_data_sz;
+    /* 16Bytes: AEAD authentication tag
+     *
+     * [RFC5116 AEAD] Section 5.1
+     *  An authentication tag with a length of 16 octets (128bits) is used.
+     *
+     * [RFC9001 QUIC-TLS] Section 5.3
+     *  These cipher suites have a 16-byte authentication tag and
+     *  produce an output 16 bytes larger than their input.
+     */
+    const size_t dst_sz = packet_in->pi_data_sz - 16;
     unsigned char new_secret[EVP_MAX_KEY_LENGTH];
     struct crypto_ctx crypto_ctx_buf;
     char secret_str[EVP_MAX_KEY_LENGTH * 2 + 1];

--- a/src/liblsquic/lsquic_mm.h
+++ b/src/liblsquic/lsquic_mm.h
@@ -44,6 +44,7 @@ struct lsquic_mm {
     TAILQ_HEAD(, lsquic_packet_in)  free_packets_in;
     SLIST_HEAD(, packet_out_buf)    packet_out_bufs[MM_N_OUT_BUCKETS];
     struct pool_stats               packet_out_bstats[MM_N_OUT_BUCKETS];
+    struct pool_stats               packet_in_bstats[MM_N_IN_BUCKETS];
     SLIST_HEAD(, packet_in_buf)     packet_in_bufs[MM_N_IN_BUCKETS];
     SLIST_HEAD(, four_k_page)       four_k_pages;
     SLIST_HEAD(, sixteen_k_page)    sixteen_k_pages;


### PR DESCRIPTION
[Reproduce]
  http_client POST large body request to http_server, like:
    http_client -H quic.test.com -s $SERVER_ADDR:$SERVER_PORT -p /1KB_char.txt -M POST -P /test/quic-data/html/10KB_char.txt -o version=h3 -n 100 -r 50000000 -R 500 -w 10 -K

[Notes]
  RFC5116 AEAD Section 5.1
    An authentication tag with a length of 16 octets (128bits) is used.

  RFC9001 QUIC-TLS Section 5.3
    These cipher suites have a 16-byte authentication tag and produce an output 16 bytes larger than their input.

@litespeedtech Please check this PR, thanks!