### PR TITLE
Fix: http_server might not send  MAX_STREAMS to increase  limits if client cancel stream prematurely

### DIFF
--- a/src/liblsquic/lsquic_stream.c
+++ b/src/liblsquic/lsquic_stream.c
@@ -1436,7 +1436,12 @@ lsquic_stream_rst_frame_sent (lsquic_stream_t *stream)
     stream->sm_qflags &= ~SMQF_SEND_RST;
     if (!(stream->sm_qflags & SMQF_SENDING_FLAGS))
         TAILQ_REMOVE(&stream->conn_pub->sending_streams, stream, next_send_stream);
-    stream->stream_flags |= STREAM_RST_SENT;
+
+    /* [RFC9000 QUIC] Section 19.4. RESET_Frames
+     *  An endpoint uses a RESET_STREAM frame (type=0x04)
+     *  to abruptly terminate the sending part of a stream.
+     */
+    stream->stream_flags |= STREAM_RST_SENT|STREAM_U_WRITE_DONE;
     maybe_finish_stream(stream);
 }
 


### PR DESCRIPTION
[BUG]
http_server might not send  MAX_STREAMS to increase  limits if client cancel stream prematurely.

[PROTOCOL]
RFC9000 3.5.
A STOP_SENDING frame requests that the receiving endpoint send a RESET_STREAM frame. An endpoint that receives a STOP_SENDING frame MUST send a RESET_STREAM frame if the stream is in the "Ready" or "Send" state. If the stream is in the "Data Sent" state, the endpoint MAY defer sending the RESET_STREAM frame until the packets containing outstanding data are acknowledged or declared lost. If any outstanding data is declared lost, the endpoint SHOULD send a RESET_STREAM frame instead of retransmitting the data.

RFC9000 19.4. RESET_Frames
An endpoint uses a RESET_STREAM frame (type=0x04) to abruptly terminate the sending part of a stream.

[Reproduce] 
Request big file and cancel stream prematurely, like: 
./max_streams_http_client -H uu.cc -s 127.0.0.1:3333 -p /100MB.txt -o version=h3 -b 80 -n 1 -r 150 -R 150
Here, http_client was build specially, binary file:
[max_streams_http_client.tar.gz](https://github.com/litespeedtech/lsquic/files/10027461/max_streams_http_client.tar.gz)