### PR TITLE
Fix handshake hole assert failed and coredump

### DIFF
--- a/src/liblsquic/lsquic_mini_conn.c
+++ b/src/liblsquic/lsquic_mini_conn.c
@@ -1055,7 +1055,11 @@ continue_handshake (struct mini_conn *mc)
      */
     TAILQ_FOREACH(packet_in, &mc->mc_packets_in, pi_next)
     {
-        assert(n_hsk_chunks < sizeof(hsk_chunks) / sizeof(hsk_chunks[0]));
+        if (n_hsk_chunks >= sizeof(hsk_chunks) / sizeof(hsk_chunks[0])) {
+            LSQ_WARN("too many handshake packets");
+            return -1;
+        }
+
         if (0 == (packet_in->pi_flags & PI_HSK_STREAM))
             continue;
         s = parse_frame(packet_in->pi_data + packet_in->pi_hsk_stream,


### PR DESCRIPTION
[Reproduction]
Assuming the total data volume of the handshake crypto stream in http_client is 1000 bytes, during actual transmission, we repeatedly send data from the range [256, 1000] while excluding the range [0, 256), creating a handshake hole scenario. As a result, http_server triggers a core dump due to an assert failure.