### PR TITLE
Rename http_server response delay to Y to not shadow log timestamp format

### DIFF
--- a/bin/http_server.c
+++ b/bin/http_server.c
@@ -1777,7 +1777,7 @@ usage (const char *prog)
 "                 write; negative means always use remaining file size.\n"
 "                 Incompatible with -w.\n"
 #endif
-"   -y DELAY    Delay response for this many seconds -- use for debugging\n"
+"   -Y DELAY    Delay response for this many seconds -- use for debugging\n"
 "   -Q ALPN     Use hq mode; ALPN could be \"hq-29\", for example.\n"
             , prog);
 }
@@ -1987,7 +1987,7 @@ main (int argc, char **argv)
                                                         "cannot use -P\n");
             exit(EXIT_FAILURE);
 #endif
-        case 'y':
+        case 'Y':
             server_ctx.delay_resp_sec = atoi(optarg);
             break;
         case 'h':


### PR DESCRIPTION
Currently both the [response delay in http_server](https://github.com/litespeedtech/lsquic/blob/0b9f50b5f0f2ce2968eaa68294db7af69abe88fc/bin/http_server.c#L1780) and the [log timestamp format](https://github.com/litespeedtech/lsquic/blob/0b9f50b5f0f2ce2968eaa68294db7af69abe88fc/bin/prog.c#L157) use the character `y` for their command line option. This PR renames the response delay option from y to Y to fix that  currently the log timestamp format is shadowed by the response delay and can not be specified for http_server. In my opinion it makes more sense to rename the response delay instead of the log timestamp format as this way the parameter can be kept consistent with other binaries in `/bin`. As the [option string in http_server](https://github.com/litespeedtech/lsquic/blob/0b9f50b5f0f2ce2968eaa68294db7af69abe88fc/bin/http_server.c#L1950) includes `Y` which is unused I assume it was the intended character for the response delay but was mistakenly written in lower case.