### PR TITLE
Fix build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@
 cmake_minimum_required(VERSION 3.0...3.23)
 
 
-PROJECT(lsquic C)
+PROJECT(lsquic C CXX)
+
+SET(LIBS "-lstdc++")
 
 OPTION(LSQUIC_FIU "Use Fault Injection in Userspace (FIU)" OFF)
 OPTION(LSQUIC_BIN "Compile example binaries that use the library" ON)

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,14 @@ WORKDIR /src
 RUN mkdir /src/lsquic
 COPY ./ /src/lsquic/
 
-RUN git clone https://github.com/google/boringssl.git && \
+RUN git clone --depth=1 https://github.com/google/boringssl.git && \
     cd boringssl && \
-    git checkout 9fc1c33e9c21439ce5f87855a6591a9324e569fd && \
     cmake . && \
     make
 
 ENV EXTRA_CFLAGS -DLSQUIC_QIR=1
 RUN cd /src/lsquic && \
-    cmake -DBORINGSSL_DIR=/src/boringssl . && \
+    cmake -DBORINGSSL_DIR=/src/boringssl -D BORINGSSL_LIB_crypto=/src/boringssl/build/crypto/libcrypto.a -DBORINGSSL_LIB_SSL=/src/boringssl/build/ssl/libssl.a . && \
     make
 
 RUN cd lsquic && cp bin/http_client /usr/bin/ && cp bin/http_server /usr/bin


### PR DESCRIPTION
This PR fix build for linux/arm64 by using latest BoringSSL version and configure CMake to link C++ symbols.