### PR TITLE
Add lsquic_engine_get_conns_count api to return current engine's conn…

### DIFF
--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -1439,6 +1439,12 @@ lsquic_engine_packet_in (lsquic_engine_t *,
         void *peer_ctx, int ecn);
 
 /**
+ * Returns current number of connections processed by the engine. Both mini and full connections included
+ */
+unsigned
+lsquic_engine_get_conns_count (lsquic_engine_t *engine);
+
+/**
  * Process tickable connections.  This function must be called often enough so
  * that packets and connections do not expire.
  */

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -2213,6 +2213,11 @@ drop_all_mini_conns (lsquic_engine_t *engine)
     cub_flush(&cub);
 }
 
+unsigned
+lsquic_engine_get_conns_count (lsquic_engine_t *engine)
+{
+    return engine->n_conns;
+}
 
 void
 lsquic_engine_process_conns (lsquic_engine_t *engine)


### PR DESCRIPTION
Sometimes its very important to know how many connections our engine currently process. For example for load balancing purposes I need to find less loaded engine and forward new connection pretender to it.
Currently I can track only established(full) connections, but cannot say how many mini connections exists. 
@gwanglst, please consider to include this api 