### PR TITLE
Fixes #518: lsquic compliance with RFC 9000 for MAX_STREAM_DATA frame

### DIFF
--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -6194,9 +6194,46 @@ process_max_stream_data_frame (struct ietf_full_conn *conn,
                                                                     stream_id);
     else
     {
-        ABORT_QUIETLY(0, TEC_STREAM_STATE_ERROR, "received MAX_STREAM_DATA "
-            "frame on never-opened stream %"PRIu64, stream_id);
-        return 0;
+        if (is_peer_initiated(conn, stream_id))
+        {
+            const lsquic_stream_id_t max_allowed =
+                    conn->ifc_max_allowed_stream_id[stream_id & SIT_MASK];
+            if (stream_id >= max_allowed)
+            {
+                ABORT_QUIETLY(0, TEC_STREAM_LIMIT_ERROR, "incoming stream "
+                                                         "%"PRIu64" exceeds allowed max of %"PRIu64,
+                              stream_id, max_allowed);
+                return 0;
+            }
+            if (conn->ifc_flags & IFC_GOING_AWAY)
+            {
+                LSQ_DEBUG("going away: reject new incoming stream %"PRIu64,
+                          stream_id);
+                maybe_schedule_ss_for_stream(conn, stream_id,
+                                             HEC_REQUEST_REJECTED);
+                return parsed_len;
+            }
+            stream = new_stream(conn, stream_id, SCF_CALL_ON_NEW);
+            if (!stream)
+            {
+                ABORT_ERROR("cannot create new stream: %s", strerror(errno));
+                return 0;
+            }
+            if (SD_BIDI == ((stream_id >> SD_SHIFT) & 1)
+                && (!valid_stream_id(conn->ifc_max_req_id)
+                    || conn->ifc_max_req_id < stream_id))
+                conn->ifc_max_req_id = stream_id;
+            if (SD_UNI == ((stream_id >> SD_SHIFT) & 1)
+                && (!valid_stream_id(conn->ifc_max_uni_req_id)
+                    || conn->ifc_max_uni_req_id < stream_id))
+                conn->ifc_max_uni_req_id = stream_id;
+        }
+        else
+        {
+            ABORT_QUIETLY(0, TEC_STREAM_STATE_ERROR, "received MAX_STREAM_DATA "
+                                                     "frame on never-opened stream %"PRIu64, stream_id);
+            return 0;
+        }
     }
 
     return parsed_len;

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -6223,10 +6223,6 @@ process_max_stream_data_frame (struct ietf_full_conn *conn,
                 && (!valid_stream_id(conn->ifc_max_req_id)
                     || conn->ifc_max_req_id < stream_id))
                 conn->ifc_max_req_id = stream_id;
-            if (SD_UNI == ((stream_id >> SD_SHIFT) & 1)
-                && (!valid_stream_id(conn->ifc_max_uni_req_id)
-                    || conn->ifc_max_uni_req_id < stream_id))
-                conn->ifc_max_uni_req_id = stream_id;
         }
         else
         {


### PR DESCRIPTION
### The story begins here: 
https://github.com/litespeedtech/lsquic/issues/518.


### The bug is: 
The function `process_max_stream_data_frame()` returns an error if it detects that the corresponding stream has not been created, causing LSQUIC to close the connection.


### According to RFC9000:
1. If this stream is **initiated by peer**, the local side should **create the receiving part of the stream** and transition to the Recv state upon receiving a max_stream_data frame (similar to how process_stream_frame() handles it).
![状态机流程](https://github.com/user-attachments/assets/be25e399-e5f2-4e3f-802c-0ad5962271f2)
![允许创建](https://github.com/user-attachments/assets/5fa5243a-4502-49a3-abc0-ec215ad6708f)

2. If this stream is **initiated by local side**, the local side should consider it as a **connection error of type STREAM_STATE_ERROR**.
![不允许创建](https://github.com/user-attachments/assets/fb001acb-c9e5-4eb0-9d84-9bc5cb5f12b0)



We submitted the solution according to RFC9000.