### PR TITLE
Fix: alternative solution for issue that split lost packet api may cause regen assert fail

### DIFF
--- a/src/liblsquic/lsquic_send_ctl.c
+++ b/src/liblsquic/lsquic_send_ctl.c
@@ -2474,7 +2474,7 @@ lsquic_send_ctl_reschedule_packets (lsquic_send_ctl_t *ctl)
     while ((packet_out = send_ctl_next_lost(ctl)))
     {
         //assert(packet_out->po_regen_sz < packet_out->po_data_sz);
-        if (packet_out->po_regen_sz == packet_out->po_data_sz) {
+        if (packet_out->po_regen_sz >= packet_out->po_data_sz) {
             LSQ_ERROR("Packet %"PRIu64" po_regen_sz is equal to po_data_sz",
                       packet_out->po_packno);
             send_ctl_destroy_chain(ctl, packet_out, NULL);

--- a/src/liblsquic/lsquic_send_ctl.c
+++ b/src/liblsquic/lsquic_send_ctl.c
@@ -2473,7 +2473,14 @@ lsquic_send_ctl_reschedule_packets (lsquic_send_ctl_t *ctl)
 
     while ((packet_out = send_ctl_next_lost(ctl)))
     {
-        assert(packet_out->po_regen_sz < packet_out->po_data_sz);
+        //assert(packet_out->po_regen_sz < packet_out->po_data_sz);
+        if (packet_out->po_regen_sz == packet_out->po_data_sz) {
+            LSQ_ERROR("Packet %"PRIu64" po_regen_sz is equal to po_data_sz",
+                      packet_out->po_packno);
+            send_ctl_destroy_chain(ctl, packet_out, NULL);
+            send_ctl_destroy_packet(ctl, packet_out);
+            continue;
+        }
         ++n;
 #if LSQUIC_CONN_STATS
         ++ctl->sc_conn_pub->conn_stats->out.retx_packets;


### PR DESCRIPTION
PR(#511) was previously submitted to address this issue, but there might be some cases that were not fully considered. 
To ensure that the lsquic assert problem does not occur here again, this commit provides a more comprehensive solution.