### PR TITLE
Remove unused function parameter for C23 compatibility

### DIFF
--- a/src/liblsquic/lsquic_di_error.c
+++ b/src/liblsquic/lsquic_di_error.c
@@ -21,7 +21,7 @@ static const struct data_in *error_data_in_ptr;
 
 
 struct data_in *
-lsquic_data_in_error_new (struct lsquic_conn_public *conn_pub)
+lsquic_data_in_error_new ()
 {
     return (struct data_in *) error_data_in_ptr;
 }


### PR DESCRIPTION
In C23, `void foo()` is equivalent to `void foo(void)`, which causes a
conflicting type error for lsquic_data_in_error_new.
https://gcc.gnu.org/gcc-15/porting_to.html

```
/var/tmp/portage/dev-libs/lsquic-4.0.12/work/lsquic-4.0.12/src/liblsquic/lsquic_di_error.c:24:1: error: conflicting types for ‘lsquic_data_in_error_new’; have ‘struct data_in *(struct lsquic_conn_public *)’
   24 | lsquic_data_in_error_new (struct lsquic_conn_public *conn_pub)
      | ^~~~~~~~~~~~~~~~~~~~~~~~
In file included from /var/tmp/portage/dev-libs/lsquic-4.0.12/work/lsquic-4.0.12/src/liblsquic/lsquic_di_error.c:17:
/var/tmp/portage/dev-libs/lsquic-4.0.12/work/lsquic-4.0.12/src/liblsquic/lsquic_data_in_if.h:109:1: note: previous declaration of ‘lsquic_data_in_error_new’ with type ‘struct data_in *(void)’
  109 | lsquic_data_in_error_new ();
      | ^~~~~~~~~~~~~~~~~~~~~~~~
```
Downstream Bug: https://bugs.gentoo.org/945037