### PR TITLE
WebTransport server support for client initiated bidi streams added.

### DIFF
--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -461,6 +461,13 @@ typedef struct ssl_ctx_st * (*lsquic_lookup_cert_f)(
 /** Transport parameter sanity checks are performed by default. */
 #define LSQUIC_DF_CHECK_TP_SANITY 1
 
+#if LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
+/** Turn off webtransport extension for server by default */
+#define LSQUIC_DF_WEBTRANSPORT_SERVER 0
+
+/** Default allowed server webtransport streams count */
+#define LSQUIC_DF_MAX_WEBTRANSPORT_SERVER_STREAMS 10
+#endif
 struct lsquic_engine_settings {
     /**
      * This is a bit mask wherein each bit corresponds to a value in
@@ -1115,6 +1122,22 @@ struct lsquic_engine_settings {
      * The default is @ref LSQUIC_DF_SEND_VERNEG.
      */
     int             es_send_verneg;
+
+#if LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
+    /**
+     * Enable datagram extension for http3 server.  Allowed values are 0 and 1.
+     *
+     * Default value is @ref LSQUIC_DF_WEBTRANSPORT_SERVER
+     */
+    int             es_webtransport_server;
+
+    /**
+     * Maximum number of webtransport streams allowed by server for a connection.
+     *
+     * Default value is @ref LSQUIC_DF_MAX_WEBTRANSPORT_SERVER_STREAMS.
+     */
+    unsigned        es_max_webtransport_server_streams;
+#endif    
 };
 
 /* Initialize `settings' to default values */
@@ -1851,6 +1874,20 @@ lsquic_stream_set_http_prio (lsquic_stream_t *,
  * functions.
  */
 lsquic_conn_t * lsquic_stream_conn(const lsquic_stream_t *s);
+
+#if LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
+void
+lsquic_stream_set_webtransport_session(lsquic_stream_t *s);
+
+int
+lsquic_stream_is_webtransport_session (const lsquic_stream_t *s);
+
+int
+lsquic_stream_is_webtransport_client_bidi_stream(const lsquic_stream_t *s);
+
+int
+lsquic_stream_get_webtransport_session_stream_id(const lsquic_stream_t *s);
+#endif
 
 /** Get connection ID */
 const lsquic_cid_t *

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -323,6 +323,10 @@ lsquic_engine_init_settings (struct lsquic_engine_settings *settings,
         settings->es_ping_period = 0;
         settings->es_noprogress_timeout
                          = LSQUIC_DF_NOPROGRESS_TIMEOUT_SERVER;
+#if LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
+        settings->es_webtransport_server = LSQUIC_DF_WEBTRANSPORT_SERVER;
+        settings->es_max_webtransport_server_streams = LSQUIC_DF_MAX_WEBTRANSPORT_SERVER_STREAMS;
+#endif
     }
     else
     {
@@ -499,7 +503,26 @@ lsquic_engine_check_settings (const struct lsquic_engine_settings *settings,
                 "the allowed maximum of %u", (unsigned) MAX_OUT_BATCH_SIZE);
         return -1;
     }
+#if LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
+    if(settings->es_webtransport_server)
+    {
+        if(!(flags & ENG_SERVER))
+        {
+            if (err_buf)
+                snprintf(err_buf, err_buf_sz, "server webtransport support enabled, but "
+                                              "ENG_SERVER flag is not set");
+            return -1;
+        }
 
+        if(settings->es_max_webtransport_server_streams == 0)
+        {
+            if (err_buf)
+                snprintf(err_buf, err_buf_sz, "server webtransport support enabled, but "
+                                              "webtransport sessions count is 0");
+            return -1;
+        }
+    }
+#endif
     return 0;
 }
 

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -3764,7 +3764,13 @@ init_http (struct ietf_full_conn *conn)
                                                     &max_risked_streams);
     if (0 != lsquic_hcso_write_settings(&conn->ifc_hcso,
                 conn->ifc_settings->es_max_header_list_size, dyn_table_size,
-                max_risked_streams, conn->ifc_flags & IFC_SERVER))
+                max_risked_streams, conn->ifc_flags & IFC_SERVER
+#if LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
+                ,
+                conn->ifc_settings->es_webtransport_server,
+                conn->ifc_settings->es_max_webtransport_server_streams
+#endif
+                ))
     {
         ABORT_WARN("cannot write SETTINGS");
         return -1;

--- a/src/liblsquic/lsquic_hcso_writer.h
+++ b/src/liblsquic/lsquic_hcso_writer.h
@@ -23,7 +23,11 @@ struct hcso_writer
 
 int
 lsquic_hcso_write_settings (struct hcso_writer *,
-                                        unsigned, unsigned, unsigned, int);
+                            unsigned, unsigned, unsigned, int
+#if LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
+                            ,int, unsigned
+#endif
+                            );
 
 int
 lsquic_hcso_write_goaway (struct hcso_writer *, lsquic_stream_id_t);

--- a/src/liblsquic/lsquic_stream.h
+++ b/src/liblsquic/lsquic_stream.h
@@ -101,6 +101,9 @@ struct hq_filter
     struct varint_read2_state   hqfi_vint2_state;
     /* No need to copy the values: use it directly */
 #define hqfi_left hqfi_vint2_state.vr2s_two
+#if LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
+#define hqfi_webtransport_session_id hqfi_vint2_state.vr2s_two
+#endif
 #define hqfi_type hqfi_vint2_state.vr2s_one
     struct varint_read_state    hqfi_vint1_state;
 #define hqfi_push_id hqfi_vint1_state.value
@@ -192,7 +195,13 @@ enum stream_b_flags
     SMBF_INCREMENTAL  = 1 <<11,  /* Value of the "incremental" HTTP Priority parameter */
     SMBF_HPRIO_SET    = 1 <<12,  /* Extensible HTTP Priorities have been set once */
     SMBF_DELAY_ONCLOSE= 1 <<13,  /* Delay calling on_close() until peer ACKs everything */
+#if LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
+    SMBF_WEBTRANSPORT_SESSION_STREAM     = 1 <<14,  /* WEBTRANSPORT session stream */
+    SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM = 1 <<15,  /* WEBTRANSPORT client initiated bidi stream */
+#define N_SMBF_FLAGS 16
+#else
 #define N_SMBF_FLAGS 14
+#endif
 };
 
 
@@ -377,7 +386,9 @@ struct lsquic_stream
     enum stream_d_flags             sm_dflags:8;
     signed char                     sm_saved_want_write;
     signed char                     sm_has_frame;
-
+#if LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
+    lsquic_stream_id_t              webtransport_session_stream_id;
+#endif
 #if LSQUIC_KEEP_STREAM_HISTORY
     sm_hist_idx_t                   sm_hist_idx;
 #endif


### PR DESCRIPTION
Both Firefox and Chrome supported. Per my observation currently suppoted WebTransport version is https://datatracker.ietf.org/doc/draft-ietf-webtrans-http3/05/

closes #386