### PR TITLE
Fix up sha256, lshkdf_* and lsquic_c255_* apis to be compatible with openssl

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ task:
         - cd boringssl
         # This is so that both GQUIC and IETF branches build.  Just picking
         # a known good revision:
-        - git checkout a2278d4d2cabe73f6663e3299ea7808edfa306b9
+        - git checkout 0.20250807.0
         - cmake .
         - make
         - cd -

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,7 +238,7 @@ ENDIF()
 
 if ("${STATIC_BUILD}" STREQUAL "yes")
     SET(CMAKE_REQUIRED_LIBRARIES "${LIBSSL_LIB_ssl};${LIBSSL_LIB_crypto}")
-    SET(CMAKE_EXE_LINKER_FLAGS "-pthread -lstdc++")
+    LIST(APPEND CMAKE_REQUIRED_LIBRARIES "-pthread -lstdc++")
 ELSE()
     SET(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath=${LIBSSL_DIR} -L${LIBSSL_DIR} -lssl -lcrypto")
 ENDIF()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /wd4459")	# hide global declaration
 SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /wd4706")	# assignment within conditional expression
 SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /wd4090")	# different 'const' qualifier (TODO: debug ls-sfparser.c)
 SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /wd4305")	# truncation from double to float
+SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} /wd4201") # Allow nameless structs
 SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -W4 -WX -Zi -DWIN32_LEAN_AND_MEAN -DNOMINMAX -D_CRT_SECURE_NO_WARNINGS -I${CMAKE_CURRENT_SOURCE_DIR}/wincompat")
 IF(LSQUIC_SHARED_LIB)
     SET(MY_CMAKE_FLAGS "${MY_CMAKE_FLAGS} -DLSQUIC_SHARED_LIB")

--- a/appveyor-linux.yml
+++ b/appveyor-linux.yml
@@ -25,7 +25,7 @@ install:
 
         cd boringssl
 
-        git checkout cf8d3ad3cea51cf7184307d54f465da62b7d8408
+        git checkout 0.20250807.0
 
         cmake .
 

--- a/appveyor-windows.cmd
+++ b/appveyor-windows.cmd
@@ -6,7 +6,7 @@ if exist ".\boringssl\CMakeLists.txt" (
     git clone https://boringssl.googlesource.com/boringssl
     cd boringssl
     git checkout 0.20250807.0
-    cmake -DCMAKE_GENERATOR_PLATFORM=x64 --config Debug -DBUILD_SHARED_LIBS=OFF -DOPENSSL_NO_ASM=1 .
+    cmake -DCMAKE_GENERATOR_PLATFORM=x64 -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DOPENSSL_NO_ASM=1 .
     msbuild /m ALL_BUILD.vcxproj
     cd ..
 )

--- a/appveyor-windows.cmd
+++ b/appveyor-windows.cmd
@@ -5,7 +5,7 @@ if exist ".\boringssl\CMakeLists.txt" (
 ) else (
     git clone https://boringssl.googlesource.com/boringssl
     cd boringssl
-    git checkout cf8d3ad3cea51cf7184307d54f465da62b7d8408
+    git checkout 0.20250807.0
     cmake -DCMAKE_GENERATOR_PLATFORM=x64 --config Debug -DBUILD_SHARED_LIBS=OFF -DOPENSSL_NO_ASM=1 .
     msbuild /m ALL_BUILD.vcxproj
     cd ..

--- a/appveyor-windows.yml
+++ b/appveyor-windows.yml
@@ -1,6 +1,6 @@
 version: 1.{branch}.{build}
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 init:
 


### PR DESCRIPTION
The sha256, lshkdf_* and lsquic_c255_* apis use libcrypto apis calls that are unique to boringssl.  We should fix those up to use API's that are common between boringssl and openssl so that lsquic can be built with either library.

This is in pursuit of #113 so that, eventually openssl can be used as TLS backend for lsquic.