### PR TITLE
Fix Docker image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN git clone --depth=1 https://github.com/google/boringssl.git && \
 
 ENV EXTRA_CFLAGS -DLSQUIC_QIR=1
 RUN cd /src/lsquic && \
-    cmake -DLIBSSL_DIR=/src/boringssl -D LIBSSL_LIB_crypto=/src/boringssl/build/crypto/libcrypto.a -DLIBSSL_LIB_SSL=/src/boringssl/build/ssl/libssl.a . && \
+    cmake -DLIBSSL_DIR=/src/boringssl . && \
     make
 
 RUN cd lsquic && cp bin/http_client /usr/bin/ && cp bin/http_server /usr/bin

--- a/bin/http_client.c
+++ b/bin/http_client.c
@@ -49,6 +49,9 @@
 #include "../src/liblsquic/lsquic_hash.h"
 #if LSQUIC_QIR
 /* include directly for reset_stream testing */
+#include "../src/liblsquic/lsquic_sfcw.h"
+#include "../src/liblsquic/lsquic_varint.h"
+#include "../src/liblsquic/lsquic_hq.h"
 #include "../src/liblsquic/lsquic_stream.h"
 /* include directly for retire_cid testing */
 #include "../src/liblsquic/lsquic_conn.h"


### PR DESCRIPTION
While trying to build a local lsquic docker image for interop testing, I noticed a few problems.

1) I had added a space in the cmake directive for LIBSSL_LIB_ssl which
   doesn't need to be there, but both the LIBSSL_LIB_ssl and
   LIBSSL_LIB_crypto macros don't need to be specified anymore as the
   cmake infrastructure detects those properly, so lets just remove
   them.

2) The http_client.c file fails to build in the docker image:

8.492 In file included from /src/lsquic/bin/http_client.c:52: 8.492 /src/lsquic/bin/../src/liblsquic/lsquic_stream.h:87:25: error: field 'shf_frame_type' has incomplete type
8.492    87 |     enum hq_frame_type  shf_frame_type;
8.492       |                         ^~~~~~~~~~~~~~
8.492 /src/lsquic/bin/../src/liblsquic/lsquic_stream.h:101:33: error: field 'hqfi_vint2_state' has incomplete type
8.492   101 |     struct varint_read2_state   hqfi_vint2_state;
8.492       |                                 ^~~~~~~~~~~~~~~~
8.492 /src/lsquic/bin/../src/liblsquic/lsquic_stream.h:108:33: error: field 'hqfi_vint1_state' has incomplete type
8.492   108 |     struct varint_read_state    hqfi_vint1_state;
8.492       |                                 ^~~~~~~~~~~~~~~~
8.492 /src/lsquic/bin/../src/liblsquic/lsquic_stream.h:284:5: error: unknown type name 'lsquic_sfcw_t'
8.492   284 |     lsquic_sfcw_t                   fc;
8.492       |     ^~~~~~~~~~~~~

It appears some header includes are missing from the build.  It appears the last rebuild of the container was about 2 months ago, so I imagine some intervening reorganization broke this and didn't get noticed.  Fix that up so the container builds properly.