### PR TITLE
Fix the no-progress timeout logic

### DIFF
--- a/src/liblsquic/lsquic_alarmset.c
+++ b/src/liblsquic/lsquic_alarmset.c
@@ -53,6 +53,7 @@ const char *const lsquic_alid2str[] =
     [AL_BLOCKED_KA] = "BLOCKED_KA",
     [AL_MTU_PROBE]  = "MTU_PROBE",
     [AL_PACK_TOL]   = "PACK_TOL",
+    [AL_USER_STREAM] = "USER_STREAM",
 };
 
 

--- a/src/liblsquic/lsquic_alarmset.h
+++ b/src/liblsquic/lsquic_alarmset.h
@@ -39,6 +39,7 @@ enum alarm_id {
     AL_SESS_TICKET,
     AL_BLOCKED_KA,      /* Blocked Keep-Alive */
     AL_PACK_TOL,        /* Calculate packet tolerance */
+    AL_USER_STREAM,
     MAX_LSQUIC_ALARMS
 };
 
@@ -61,6 +62,7 @@ enum alarm_id_bit {
     ALBIT_BLOCKED_KA  = 1 << AL_BLOCKED_KA,
     ALBIT_MTU_PROBE = 1 << AL_MTU_PROBE,
     ALBIT_PACK_TOL = 1 << AL_PACK_TOL,
+    ALBIT_USER_STREAM = 1 << AL_USER_STREAM,
 };
 
 

--- a/src/liblsquic/lsquic_conn.h
+++ b/src/liblsquic/lsquic_conn.h
@@ -297,6 +297,12 @@ struct conn_iface
     int
     (*ci_get_info) (lsquic_conn_t *conn, struct lsquic_conn_info *info);
 
+    /* Used by the stream module to report that one of the user streams has
+     * been read from or written to.  This is what underpins the "no progress
+     * timeout" mechanism: see @ref es_noprogress_timeout.
+     */
+    void
+    (*ci_user_stream_progress) (struct lsquic_conn *);
 };
 
 #define LSCONN_CCE_BITS 3

--- a/src/liblsquic/lsquic_conn_public.h
+++ b/src/liblsquic/lsquic_conn_public.h
@@ -64,8 +64,6 @@ struct lsquic_conn_public {
      */
     unsigned                        bytes_in;   /* successfully processed */
     unsigned                        bytes_out;
-    /* Used for no-progress timeout */
-    lsquic_time_t                   last_tick, last_prog;
     unsigned                        max_peer_ack_usec;
     uint8_t                         n_special_streams;
 };

--- a/src/liblsquic/lsquic_full_conn.c
+++ b/src/liblsquic/lsquic_full_conn.c
@@ -3373,6 +3373,14 @@ full_conn_ci_ack_rollback (struct lsquic_conn *lconn, struct ack_state *opaque)
 }
 
 
+static int
+noprogress_timeout_is_enabled (const struct full_conn *conn)
+{
+    /* Once set, this alarm is always enabled */
+    return 0 != lsquic_alarmset_is_set(&conn->fc_alset, AL_USER_STREAM);
+}
+
+
 static void
 full_conn_ci_user_stream_progress (struct lsquic_conn *lconn)
 {
@@ -3380,7 +3388,7 @@ full_conn_ci_user_stream_progress (struct lsquic_conn *lconn)
     lsquic_time_t const expiry = conn->fc_last_tick
                                         + conn->fc_enpub->enp_noprog_timeout;
 
-    if (lsquic_alarmset_is_set(&conn->fc_alset, AL_USER_STREAM)
+    if (noprogress_timeout_is_enabled(conn)
                         && expiry > conn->fc_alset.as_expiry[AL_USER_STREAM])
     {
         lsquic_alarmset_set(&conn->fc_alset, AL_USER_STREAM, expiry);

--- a/src/liblsquic/lsquic_full_conn.c
+++ b/src/liblsquic/lsquic_full_conn.c
@@ -119,7 +119,6 @@ enum full_conn_flags {
     FC_ABORT_COMPLAINED
                       = (1 <<23),
     FC_GOT_SREJ       = (1 <<24),   /* Don't schedule ACK alarm */
-    FC_NOPROG_TIMEOUT = (1 <<25),
 };
 
 #define FC_IMMEDIATE_CLOSE_FLAGS \
@@ -225,6 +224,7 @@ struct full_conn
     STAILQ_HEAD(, stream_id_to_reset)
                                  fc_stream_ids_to_reset;
     lsquic_time_t                fc_saved_ack_received;
+    lsquic_time_t                fc_last_tick;
     struct network_path          fc_path;
     unsigned                     fc_orig_versions;      /* Client only */
     enum enc_level               fc_crypto_enc_level;
@@ -257,6 +257,9 @@ static const struct ver_neg server_ver_neg;
 
 static void
 idle_alarm_expired (enum alarm_id, void *ctx, lsquic_time_t expiry, lsquic_time_t now);
+
+static void
+user_stream_alarm_expired (enum alarm_id, void *ctx, lsquic_time_t expiry, lsquic_time_t now);
 
 static void
 ping_alarm_expired (enum alarm_id, void *ctx, lsquic_time_t expiry, lsquic_time_t now);
@@ -599,6 +602,24 @@ is_handshake_stream_id (const struct full_conn *conn,
 }
 
 
+static void
+maybe_install_noprogress_timer (struct full_conn *conn)
+{
+    if (conn->fc_settings->es_noprogress_timeout)
+    {
+        LSQ_DEBUG("enable noprogress timeout of %u seconds",
+                                    conn->fc_settings->es_noprogress_timeout);
+        conn->fc_last_tick = lsquic_time_now();
+        lsquic_alarmset_init_alarm(&conn->fc_alset, AL_USER_STREAM,
+                                            user_stream_alarm_expired, conn);
+        lsquic_alarmset_set(&conn->fc_alset, AL_USER_STREAM,
+                    conn->fc_last_tick + conn->fc_enpub->enp_noprog_timeout);
+    }
+    else
+        LSQ_DEBUG("noprogress timeout disabled");
+}
+
+
 static struct full_conn *
 new_conn_common (lsquic_cid_t cid, struct lsquic_engine_public *enpub,
                  unsigned flags, enum lsquic_version version)
@@ -700,8 +721,6 @@ new_conn_common (lsquic_cid_t cid, struct lsquic_engine_public *enpub,
     if (conn->fc_settings->es_support_push)
         conn->fc_flags |= FC_SUPPORT_PUSH;
     conn->fc_conn.cn_n_cces = sizeof(conn->fc_cces) / sizeof(conn->fc_cces[0]);
-    if (conn->fc_settings->es_noprogress_timeout)
-        conn->fc_flags |= FC_NOPROG_TIMEOUT;
     return conn;
 
   cleanup_on_error:
@@ -787,9 +806,11 @@ lsquic_gquic_full_conn_client_new (struct lsquic_engine_public *enpub,
                 .stream_if     = &lsquic_client_hsk_stream_if;
     conn->fc_stream_ifs[STREAM_IF_HSK].stream_if_ctx = &conn->fc_hsk_ctx.client;
     conn->fc_orig_versions = versions;
+    const lsquic_time_t now = lsquic_time_now();
+    conn->fc_last_tick = now;
     if (conn->fc_settings->es_handshake_to)
         lsquic_alarmset_set(&conn->fc_alset, AL_HANDSHAKE,
-                    lsquic_time_now() + conn->fc_settings->es_handshake_to);
+                                    now + conn->fc_settings->es_handshake_to);
     if (!new_stream_ext(conn, hsk_stream_id(conn), STREAM_IF_HSK,
             SCF_CALL_ON_NEW|SCF_DI_AUTOSWITCH|SCF_CRITICAL|SCF_CRYPTO
             |(conn->fc_conn.cn_version >= LSQVER_050 ? SCF_CRYPTO_FRAMES : 0)))
@@ -861,6 +882,9 @@ lsquic_gquic_full_conn_server_new (struct lsquic_engine_public *enpub,
 
     conn->fc_hsk_ctx.server.lconn = lconn_full;
     conn->fc_hsk_ctx.server.enpub = enpub;
+
+    const lsquic_time_t now = lsquic_time_now();
+    conn->fc_last_tick = now;
 
     /* TODO Optimize: we don't need an actual crypto stream and handler
      * on the server side, as we don't do anything with it.  We can
@@ -1002,7 +1026,8 @@ lsquic_gquic_full_conn_server_new (struct lsquic_engine_public *enpub,
         if (have_outgoing_ack)
             reset_ack_state(conn);
         lsquic_alarmset_set(&conn->fc_alset, AL_IDLE,
-                    lsquic_time_now() + conn->fc_settings->es_idle_conn_to);
+                                    now + conn->fc_settings->es_idle_conn_to);
+        maybe_install_noprogress_timer(conn);
         EV_LOG_CONN_EVENT(LSQUIC_LOG_CONN_ID, "created full connection");
         LSQ_INFO("Created new server connection");
         return &conn->fc_conn;
@@ -2518,21 +2543,22 @@ idle_alarm_expired (enum alarm_id al_id, void *ctx, lsquic_time_t expiry,
 {
     struct full_conn *conn = ctx;
 
-    if ((conn->fc_flags & FC_NOPROG_TIMEOUT)
-        && conn->fc_pub.last_prog + conn->fc_enpub->enp_noprog_timeout < now)
-    {
-        LSQ_DEBUG("connection timed out due to lack of progress");
-        EV_LOG_CONN_EVENT(LSQUIC_LOG_CONN_ID, "connection timed out due to "
-                                                            "lack of progress");
-        /* Different flag so that CONNECTION_CLOSE frame is sent */
-        conn->fc_flags |= FC_ABORTED;
-    }
-    else
-    {
-        LSQ_DEBUG("connection timed out");
-        EV_LOG_CONN_EVENT(LSQUIC_LOG_CONN_ID, "connection timed out");
-        conn->fc_flags |= FC_TIMED_OUT;
-    }
+    LSQ_DEBUG("connection timed out");
+    EV_LOG_CONN_EVENT(LSQUIC_LOG_CONN_ID, "connection timed out");
+    conn->fc_flags |= FC_TIMED_OUT;
+}
+
+
+static void
+user_stream_alarm_expired (enum alarm_id al_id, void *ctx,
+                                    lsquic_time_t expiry, lsquic_time_t now)
+{
+    struct full_conn *conn = ctx;
+
+    LSQ_DEBUG("connection timed out due to lack of progress");
+    EV_LOG_CONN_EVENT(LSQUIC_LOG_CONN_ID, "connection timed out due to "
+                                                        "lack of progress");
+    conn->fc_flags |= FC_ABORTED;
 }
 
 
@@ -3347,27 +3373,17 @@ full_conn_ci_ack_rollback (struct lsquic_conn *lconn, struct ack_state *opaque)
 }
 
 
-/* This should be called before lsquic_alarmset_ring_expired() */
 static void
-maybe_set_noprogress_alarm (struct full_conn *conn, lsquic_time_t now)
+full_conn_ci_user_stream_progress (struct lsquic_conn *lconn)
 {
-    lsquic_time_t exp;
+    struct full_conn *const conn = (struct full_conn *) lconn;
+    lsquic_time_t const expiry = conn->fc_last_tick
+                                        + conn->fc_enpub->enp_noprog_timeout;
 
-    if (conn->fc_flags & FC_NOPROG_TIMEOUT)
+    if (lsquic_alarmset_is_set(&conn->fc_alset, AL_USER_STREAM)
+                        && expiry > conn->fc_alset.as_expiry[AL_USER_STREAM])
     {
-        if (conn->fc_pub.last_tick)
-        {
-            exp = conn->fc_pub.last_prog + conn->fc_enpub->enp_noprog_timeout;
-            if (!lsquic_alarmset_is_set(&conn->fc_alset, AL_IDLE)
-                                    || exp < conn->fc_alset.as_expiry[AL_IDLE])
-                lsquic_alarmset_set(&conn->fc_alset, AL_IDLE, exp);
-            conn->fc_pub.last_tick = now;
-        }
-        else
-        {
-            conn->fc_pub.last_tick = now;
-            conn->fc_pub.last_prog = now;
-        }
+        lsquic_alarmset_set(&conn->fc_alset, AL_USER_STREAM, expiry);
     }
 }
 
@@ -3428,7 +3444,7 @@ full_conn_ci_tick (lsquic_conn_t *lconn, lsquic_time_t now)
         conn->fc_flags &= ~FC_HAVE_SAVED_ACK;
     }
 
-    maybe_set_noprogress_alarm(conn, now);
+    conn->fc_last_tick = now;
 
     lsquic_send_ctl_tick_in(&conn->fc_send_ctl, now);
     lsquic_send_ctl_set_buffer_stream_packets(&conn->fc_send_ctl, 1);
@@ -3662,20 +3678,6 @@ full_conn_ci_tick (lsquic_conn_t *lconn, lsquic_time_t now)
 
 
 static void
-set_earliest_idle_alarm (struct full_conn *conn, lsquic_time_t idle_conn_to)
-{
-    lsquic_time_t exp;
-
-    if (conn->fc_pub.last_prog
-        && (assert(conn->fc_flags & FC_NOPROG_TIMEOUT),
-            exp = conn->fc_pub.last_prog + conn->fc_enpub->enp_noprog_timeout,
-            exp < idle_conn_to))
-        idle_conn_to = exp;
-    lsquic_alarmset_set(&conn->fc_alset, AL_IDLE, idle_conn_to);
-}
-
-
-static void
 full_conn_ci_packet_in (lsquic_conn_t *lconn, lsquic_packet_in_t *packet_in)
 {
     struct full_conn *conn = (struct full_conn *) lconn;
@@ -3683,7 +3685,7 @@ full_conn_ci_packet_in (lsquic_conn_t *lconn, lsquic_packet_in_t *packet_in)
 #if LSQUIC_CONN_STATS
     conn->fc_stats.in.bytes += packet_in->pi_data_sz;
 #endif
-    set_earliest_idle_alarm(conn,
+    lsquic_alarmset_set(&conn->fc_alset, AL_IDLE,
                 packet_in->pi_received + conn->fc_settings->es_idle_conn_to);
     if (0 == (conn->fc_flags & FC_ERROR))
         if (0 != process_incoming_packet(conn, packet_in))
@@ -3759,6 +3761,7 @@ full_conn_ci_hsk_done (lsquic_conn_t *lconn, enum lsquic_hsk_status status)
                                                                         status);
     if (status == LSQ_HSK_OK || status == LSQ_HSK_RESUMED_OK)
     {
+        maybe_install_noprogress_timer(conn);
         if (conn->fc_stream_ifs[STREAM_IF_STD].stream_if->on_sess_resume_info)
             conn->fc_conn.cn_esf.g->esf_maybe_dispatch_sess_resume(
                 conn->fc_conn.cn_enc_session,
@@ -4574,6 +4577,7 @@ static const struct conn_iface full_conn_iface = {
     .ci_write_ack            =  full_conn_ci_write_ack,
     .ci_push_stream          =  full_conn_ci_push_stream,
     .ci_tls_alert            =  full_conn_ci_tls_alert,
+    .ci_user_stream_progress =  full_conn_ci_user_stream_progress,
 };
 
 static const struct conn_iface *full_conn_iface_ptr = &full_conn_iface;

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -8408,6 +8408,14 @@ write_datagram (struct ietf_full_conn *conn)
 }
 
 
+static int
+noprogress_timeout_is_enabled (const struct ietf_full_conn *conn)
+{
+    /* Once set, this alarm is always enabled */
+    return 0 != lsquic_alarmset_is_set(&conn->ifc_alset, AL_USER_STREAM);
+}
+
+
 static void
 ietf_full_conn_ci_user_stream_progress (struct lsquic_conn *lconn)
 {
@@ -8415,7 +8423,7 @@ ietf_full_conn_ci_user_stream_progress (struct lsquic_conn *lconn)
     lsquic_time_t const expiry = conn->ifc_last_tick
                                         + conn->ifc_enpub->enp_noprog_timeout;
 
-    if (lsquic_alarmset_is_set(&conn->ifc_alset, AL_USER_STREAM)
+    if (noprogress_timeout_is_enabled(conn)
                         && expiry > conn->ifc_alset.as_expiry[AL_USER_STREAM])
     {
         lsquic_alarmset_set(&conn->ifc_alset, AL_USER_STREAM, expiry);

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -153,7 +153,7 @@ enum ifull_conn_flags
 enum more_flags
 {
     MF_VALIDATE_PATH    = 1 << 0,
-    MF_NOPROG_TIMEOUT   = 1 << 1,
+    /* HOLE */                      /* <- Hole!  Reuse me! */
     MF_CHECK_MTU_PROBE  = 1 << 2,
     MF_IGNORE_MISSING   = 1 << 3,
     MF_CONN_CLOSE_PACK  = 1 << 4,   /* CONNECTION_CLOSE has been packetized */
@@ -524,6 +524,7 @@ struct ietf_full_conn
     }                           ifc_u;
     lsquic_time_t               ifc_idle_to;
     lsquic_time_t               ifc_ping_period;
+    lsquic_time_t               ifc_last_tick;
     struct lsquic_hash         *ifc_bpus;
     uint64_t                    ifc_last_max_data_off_sent;
     struct packet_tolerance_stats
@@ -662,21 +663,22 @@ idle_alarm_expired (enum alarm_id al_id, void *ctx, lsquic_time_t expiry,
 {
     struct ietf_full_conn *const conn = (struct ietf_full_conn *) ctx;
 
-    if ((conn->ifc_mflags & MF_NOPROG_TIMEOUT)
-        && conn->ifc_pub.last_prog + conn->ifc_enpub->enp_noprog_timeout < now)
-    {
-        EV_LOG_CONN_EVENT(LSQUIC_LOG_CONN_ID, "connection timed out due to "
-                                                            "lack of progress");
-        /* Different flag so that CONNECTION_CLOSE frame is sent */
-        ABORT_QUIETLY(0, TEC_APPLICATION_ERROR,
-                                "connection timed out due to lack of progress");
-    }
-    else
-    {
-        LSQ_DEBUG("connection timed out");
-        EV_LOG_CONN_EVENT(LSQUIC_LOG_CONN_ID, "connection timed out");
-        conn->ifc_flags |= IFC_TIMED_OUT;
-    }
+    LSQ_DEBUG("connection timed out");
+    EV_LOG_CONN_EVENT(LSQUIC_LOG_CONN_ID, "connection timed out");
+    conn->ifc_flags |= IFC_TIMED_OUT;
+}
+
+
+static void
+user_stream_alarm_expired (enum alarm_id al_id, void *ctx,
+                                    lsquic_time_t expiry, lsquic_time_t now)
+{
+    struct ietf_full_conn *const conn = (struct ietf_full_conn *) ctx;
+
+    EV_LOG_CONN_EVENT(LSQUIC_LOG_CONN_ID, "connection timed out due to "
+                                                        "lack of progress");
+    ABORT_QUIETLY(0, TEC_APPLICATION_ERROR,
+                            "connection timed out due to lack of progress");
 }
 
 
@@ -1336,8 +1338,6 @@ ietf_full_conn_init (struct ietf_full_conn *conn,
     conn->ifc_ping_unretx_thresh = 20;
     conn->ifc_max_retx_since_last_ack = MAX_RETR_PACKETS_SINCE_LAST_ACK;
     conn->ifc_max_ack_delay = ACK_TIMEOUT;
-    if (conn->ifc_settings->es_noprogress_timeout)
-        conn->ifc_mflags |= MF_NOPROG_TIMEOUT;
     if (conn->ifc_settings->es_ext_http_prio)
         conn->ifc_pii = &ext_prio_iter_if;
     else
@@ -1363,6 +1363,7 @@ lsquic_ietf_full_conn_client_new (struct lsquic_engine_public *enpub,
     if (!conn)
         goto err0;
     now = lsquic_time_now();
+    conn->ifc_last_tick = now;
     /* Set the flags early so that correct CID is used for logging */
     conn->ifc_conn.cn_flags |= LSCONN_IETF;
     conn->ifc_conn.cn_cces = conn->ifc_cces;
@@ -1527,6 +1528,7 @@ lsquic_ietf_full_conn_server_new (struct lsquic_engine_public *enpub,
     if (!conn)
         goto err0;
     now = lsquic_time_now();
+    conn->ifc_last_tick = now;
     conn->ifc_conn.cn_cces = conn->ifc_cces;
     conn->ifc_conn.cn_n_cces = sizeof(conn->ifc_cces)
                                                 / sizeof(conn->ifc_cces[0]);
@@ -3811,6 +3813,23 @@ init_http (struct ietf_full_conn *conn)
     return 0;
 }
 
+static void
+maybe_install_noprogress_timer (struct ietf_full_conn *conn)
+{
+    if (conn->ifc_settings->es_noprogress_timeout)
+    {
+        LSQ_DEBUG("enable noprogress timeout of %u seconds",
+                                    conn->ifc_settings->es_noprogress_timeout);
+        conn->ifc_last_tick = lsquic_time_now();
+        lsquic_alarmset_init_alarm(&conn->ifc_alset, AL_USER_STREAM,
+                                            user_stream_alarm_expired, conn);
+        lsquic_alarmset_set(&conn->ifc_alset, AL_USER_STREAM,
+                    conn->ifc_last_tick + conn->ifc_enpub->enp_noprog_timeout);
+    }
+    else
+        LSQ_DEBUG("noprogress timeout disabled");
+}
+
 
 static int
 handshake_ok (struct lsquic_conn *lconn)
@@ -3904,6 +3923,7 @@ handshake_ok (struct lsquic_conn *lconn)
 
     if (can_issue_cids(conn))
         conn->ifc_send_flags |= SF_SEND_NEW_CID;
+    maybe_install_noprogress_timer(conn);
     maybe_create_delayed_streams(conn);
 
     if (!(conn->ifc_flags & IFC_SERVER))
@@ -6064,10 +6084,6 @@ process_ping_frame (struct ietf_full_conn *conn,
     if (conn->ifc_flags & IFC_SERVER)
         log_conn_flow_control(conn);
 
-    LSQ_DEBUG("received PING frame, update last progress to %"PRIu64,
-                                            conn->ifc_pub.last_tick);
-    conn->ifc_pub.last_prog = conn->ifc_pub.last_tick;
-
     return 1;
 }
 
@@ -7916,29 +7932,15 @@ process_incoming_packet_fast (struct ietf_full_conn *conn,
 
 
 static void
-set_earliest_idle_alarm (struct ietf_full_conn *conn, lsquic_time_t idle_conn_to)
-{
-    lsquic_time_t exp;
-
-    if (conn->ifc_pub.last_prog
-        && (assert(conn->ifc_mflags & MF_NOPROG_TIMEOUT),
-            exp = conn->ifc_pub.last_prog + conn->ifc_enpub->enp_noprog_timeout,
-            exp < idle_conn_to))
-        idle_conn_to = exp;
-    if (idle_conn_to)
-        lsquic_alarmset_set(&conn->ifc_alset, AL_IDLE, idle_conn_to);
-}
-
-
-static void
 ietf_full_conn_ci_packet_in (struct lsquic_conn *lconn,
                              struct lsquic_packet_in *packet_in)
 {
     struct ietf_full_conn *conn = (struct ietf_full_conn *) lconn;
 
     CONN_STATS(in.bytes, packet_in->pi_data_sz);
-    set_earliest_idle_alarm(conn, conn->ifc_idle_to
-                    ? packet_in->pi_received + conn->ifc_idle_to : 0);
+    if (conn->ifc_idle_to)
+        lsquic_alarmset_set(&conn->ifc_alset, AL_IDLE,
+                                packet_in->pi_received + conn->ifc_idle_to);
     if (0 == (conn->ifc_flags & IFC_IMMEDIATE_CLOSE_FLAGS))
         if (0 != conn->ifc_process_incoming_packet(conn, packet_in))
             conn->ifc_flags |= IFC_ERROR;
@@ -8091,31 +8093,6 @@ static void (*const send_funcs[N_SEND])(
     |SF_SEND_PING|SF_SEND_HANDSHAKE_DONE\
     |SF_SEND_ACK_FREQUENCY\
     |SF_SEND_STOP_SENDING|SF_SEND_NEW_TOKEN)
-
-
-/* This should be called before lsquic_alarmset_ring_expired() */
-static void
-maybe_set_noprogress_alarm (struct ietf_full_conn *conn, lsquic_time_t now)
-{
-    lsquic_time_t exp;
-
-    if (conn->ifc_mflags & MF_NOPROG_TIMEOUT)
-    {
-        if (conn->ifc_pub.last_tick)
-        {
-            exp = conn->ifc_pub.last_prog + conn->ifc_enpub->enp_noprog_timeout;
-            if (!lsquic_alarmset_is_set(&conn->ifc_alset, AL_IDLE)
-                                    || exp < conn->ifc_alset.as_expiry[AL_IDLE])
-                lsquic_alarmset_set(&conn->ifc_alset, AL_IDLE, exp);
-            conn->ifc_pub.last_tick = now;
-        }
-        else
-        {
-            conn->ifc_pub.last_tick = now;
-            conn->ifc_pub.last_prog = now;
-        }
-    }
-}
 
 
 static void
@@ -8431,6 +8408,21 @@ write_datagram (struct ietf_full_conn *conn)
 }
 
 
+static void
+ietf_full_conn_ci_user_stream_progress (struct lsquic_conn *lconn)
+{
+    struct ietf_full_conn *const conn = (struct ietf_full_conn *) lconn;
+    lsquic_time_t const expiry = conn->ifc_last_tick
+                                        + conn->ifc_enpub->enp_noprog_timeout;
+
+    if (lsquic_alarmset_is_set(&conn->ifc_alset, AL_USER_STREAM)
+                        && expiry > conn->ifc_alset.as_expiry[AL_USER_STREAM])
+    {
+        lsquic_alarmset_set(&conn->ifc_alset, AL_USER_STREAM, expiry);
+    }
+}
+
+
 static enum tick_st
 ietf_full_conn_ci_tick (struct lsquic_conn *lconn, lsquic_time_t now)
 {
@@ -8477,7 +8469,7 @@ ietf_full_conn_ci_tick (struct lsquic_conn *lconn, lsquic_time_t now)
         conn->ifc_flags &= ~IFC_HAVE_SAVED_ACK;
     }
 
-    maybe_set_noprogress_alarm(conn, now);
+    conn->ifc_last_tick = now;
 
     lsquic_send_ctl_tick_in(&conn->ifc_send_ctl, now);
     lsquic_send_ctl_set_buffer_stream_packets(&conn->ifc_send_ctl, 1);
@@ -9142,6 +9134,7 @@ ietf_full_conn_ci_log_stats (struct lsquic_conn *lconn)
     .ci_tick                 =  ietf_full_conn_ci_tick, \
     .ci_tls_alert            =  ietf_full_conn_ci_tls_alert, \
     .ci_want_datagram_write  =  ietf_full_conn_ci_want_datagram_write, \
+    .ci_user_stream_progress =  ietf_full_conn_ci_user_stream_progress, \
     .ci_write_ack            =  ietf_full_conn_ci_write_ack
 
 static const struct conn_iface ietf_full_conn_iface = {

--- a/src/liblsquic/lsquic_send_ctl.c
+++ b/src/liblsquic/lsquic_send_ctl.c
@@ -1296,13 +1296,6 @@ lsquic_send_ctl_got_ack (lsquic_send_ctl_t *ctl,
         ctl->sc_flags &= ~SC_WAS_QUIET;
         LSQ_DEBUG("ACK comes after a period of quiescence");
         ctl->sc_ci->cci_was_quiet(CGP(ctl), now, ctl->sc_bytes_unacked_all);
-        if (packet_out && (packet_out->po_frame_types & QUIC_FTBIT_PING)
-            && ctl->sc_conn_pub->last_prog)
-        {
-            LSQ_DEBUG("ACK to PING frame, update last progress to %"PRIu64,
-                                            ctl->sc_conn_pub->last_tick);
-            ctl->sc_conn_pub->last_prog = ctl->sc_conn_pub->last_tick;
-        }
     }
 
     if (UNLIKELY(!packet_out))

--- a/src/liblsquic/lsquic_stream.c
+++ b/src/liblsquic/lsquic_stream.c
@@ -262,11 +262,10 @@ stream_inside_callback (const lsquic_stream_t *stream)
 
 
 static void
-maybe_register_progress (struct lsquic_stream *stream)
+maybe_update_last_progress (struct lsquic_stream *stream)
 {
     struct lsquic_conn *lconn;
 
-    /* XXX: move the check into the constructor? */
     if (stream->conn_pub && !lsquic_stream_is_critical(stream))
     {
         lconn = stream->conn_pub->lconn;
@@ -1704,7 +1703,7 @@ lsquic_stream_readf (struct lsquic_stream *stream,
 
     nread = stream_readf(stream, readf, ctx);
     if (nread >= 0)
-        maybe_register_progress(stream);
+        maybe_update_last_progress(stream);
 
     return nread;
 }
@@ -3454,7 +3453,7 @@ stream_write_to_packets (lsquic_stream_t *stream, struct lsquic_reader *reader,
             if (!seen_ok++)
             {
                 maybe_conn_to_tickable_if_writeable(stream, 0);
-                maybe_register_progress(stream);
+                maybe_update_last_progress(stream);
             }
             if (fg_ctx.fgc_fin(&fg_ctx))
             {
@@ -4795,7 +4794,7 @@ lsquic_stream_get_hset (struct lsquic_stream *stream)
         stream->stream_flags |= STREAM_FIN_REACHED;
         SM_HISTORY_APPEND(stream, SHE_REACH_FIN);
     }
-    maybe_register_progress(stream);
+    maybe_update_last_progress(stream);
     LSQ_DEBUG("return header set");
     return hset;
 }

--- a/src/liblsquic/lsquic_stream.h
+++ b/src/liblsquic/lsquic_stream.h
@@ -352,11 +352,6 @@ struct lsquic_stream
 
     uint64_t                        sm_last_frame_off;
 
-#ifndef NDEBUG
-    /* Last time stream made progress */
-    lsquic_time_t                   sm_last_prog;
-#endif
-
     /* Content length specified in incoming `content-length' header field.
      * Used to verify size of DATA frames.
      */

--- a/tests/test_h3_framing.c
+++ b/tests/test_h3_framing.c
@@ -321,6 +321,11 @@ ack_rollback (struct lsquic_conn *lconn, struct ack_state *ack_state)
     s_snapshot_state |= SNAPSHOT_STATE_ROLLED_BACK;
 }
 
+static void
+user_stream_progress (struct lsquic_conn *lconn)
+{
+}
+
 static const struct conn_iface our_conn_if =
 {
     .ci_can_write_ack = can_write_ack,
@@ -328,6 +333,7 @@ static const struct conn_iface our_conn_if =
     .ci_get_path      = get_network_path,
     .ci_ack_snapshot  = ack_snapshot,
     .ci_ack_rollback  = ack_rollback,
+    .ci_user_stream_progress = user_stream_progress,
 };
 
 

--- a/tests/test_send_headers.c
+++ b/tests/test_send_headers.c
@@ -164,11 +164,17 @@ abort_error (struct lsquic_conn *lconn, int is_app,
 {
 }
 
+static void
+user_stream_progress (struct lsquic_conn *lconn)
+{
+}
+
 static const struct conn_iface our_conn_if =
 {
     .ci_can_write_ack = unit_test_doesnt_write_ack,
     .ci_get_path      = get_network_path,
     .ci_abort_error   = abort_error,
+    .ci_user_stream_progress = user_stream_progress,
 };
 
 

--- a/tests/test_stream.c
+++ b/tests/test_stream.c
@@ -342,12 +342,17 @@ write_ack (struct lsquic_conn *lconn, struct lsquic_packet_out *packet_out)
     packet_out->po_regen_sz += ack_size;
 }
 
+static void
+user_stream_progress (struct lsquic_conn *lconn)
+{
+}
 
 static const struct conn_iface our_conn_if =
 {
     .ci_can_write_ack = can_write_ack,
     .ci_get_path      = get_network_path,
     .ci_write_ack     = write_ack,
+    .ci_user_stream_progress = user_stream_progress,
 };
 
 #if LSQUIC_CONN_STATS


### PR DESCRIPTION
The two timeouts -- the idle timeout specified in the RFCs and the "user progress" timeout that we ourlselves defined -- should use different alarms.  This makes for cleaner code that is easier to reason about.

Closes #531