### PR TITLE
Fix MTU probe packets causing stream write stalls

### DIFF
--- a/src/liblsquic/lsquic_send_ctl.c
+++ b/src/liblsquic/lsquic_send_ctl.c
@@ -2600,7 +2600,12 @@ lsquic_send_ctl_have_delayed_packets (const lsquic_send_ctl_t *ctl)
 {
     const struct lsquic_packet_out *packet_out;
     TAILQ_FOREACH(packet_out, &ctl->sc_scheduled_packets, po_next)
-        if (packet_out->po_regen_sz < packet_out->po_data_sz)
+        /* MTU probes are scheduled after the delayed packet check.
+         * Exclude them to avoid blocking stream writability.
+         */
+        if (packet_out->po_flags & PO_MTU_PROBE)
+            continue;
+        else if (packet_out->po_regen_sz < packet_out->po_data_sz)
             return 1;
     return 0;
 }


### PR DESCRIPTION
MTU probe packets were incorrectly counted as delayed packets in lsquic_send_ctl_have_delayed_packets(), preventing streams from becoming writable and causing onwrite callbacks to never fire.

MTU probes are added to the scheduled queue after the delayed packet check in ietf_full_conn_ci_tick().  When counted as delayed, they cause maybe_conn_to_tickable_if_writeable() to fail, which prevents the connection from being added to the tickable queue, stalling the QPACK writer and all data transmission.

Skip MTU probe packets when checking for delayed packets.  MTU probes have special loss and ACK handling rules and should not affect stream writability checks.

Fixes: #541