### PR TITLE
Allow split buffered packet to generate one packet

### DIFF
--- a/src/liblsquic/lsquic_send_ctl.c
+++ b/src/liblsquic/lsquic_send_ctl.c
@@ -3178,7 +3178,7 @@ split_buffered_packet (lsquic_send_ctl_t *ctl,
                                                 packet_out->po_packno);
         return -1;
     }
-    if (!(count > 1 && one_ctx.fetched == 1 && one_ctx.discarded == 1))
+    if (!(count >= 1 && one_ctx.fetched == 1 && one_ctx.discarded == 1))
     {
         /* A bit of insurance, this being new code */
         LSQ_WARN("unexpected values resizing buffered packet: count: %u; "


### PR DESCRIPTION
This appears to be a case where DPLPMTUD increases a path's MTU.  This makes it possible for a packet that needs to be split to generate just one packet, as the newly allocated packet is larger than the original packet.

It is possible to optimize this scenario, but it does not happen often and so it is better to keep the code simple.

Fixes issue #505.