### PR TITLE
New API: Add per-connection send rate throttling

### DIFF
--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -2118,6 +2118,26 @@ lsquic_conn_get_sni (lsquic_conn_t *);
 void
 lsquic_conn_abort (lsquic_conn_t *);
 
+/**
+ * Connection parameter identifiers for use with lsquic_conn_set_param()
+ * and lsquic_conn_get_param().
+ */
+enum lsquic_conn_param
+{
+    /**
+     * Maximum pacing rate in bytes per second.
+     * Type: uint64_t
+     * Default: 0 (no limit, controlled by congestion control)
+     *
+     * When set to non-zero, limits the connection's send rate regardless
+     * of what the congestion control algorithm calculates.
+     *
+     * Important: This parameter only works when packet pacing is enabled.
+     * Pacing must be turned on via es_pace_packets in lsquic_engine_settings.
+     */
+    LSQCP_MAX_PACING_RATE = 1,
+};
+
 struct lsquic_conn_info
 {
     uint32_t lci_cwnd;
@@ -2132,10 +2152,49 @@ struct lsquic_conn_info
     uint64_t lci_pkts_lost;
     uint64_t lci_pkts_retx;
     uint64_t lci_bw_estimate;
+    uint64_t lci_max_pacing_rate;
 };
 
 int
 lsquic_conn_get_info (lsquic_conn_t *conn, struct lsquic_conn_info *info);
+
+/**
+ * Set a connection parameter.
+ *
+ * @param conn      Connection object
+ * @param param     Parameter to set (from enum lsquic_conn_param)
+ * @param value     Pointer to parameter value
+ * @param value_len Size of value in bytes
+ * @return          0 on success, -1 on error
+ *
+ * Example:
+ *   uint64_t max_rate = 5000000; // 5 MB/sec
+ *   lsquic_conn_set_param(conn, LSQCP_MAX_PACING_RATE,
+ *                         &max_rate, sizeof(max_rate));
+ */
+int
+lsquic_conn_set_param (lsquic_conn_t *conn, enum lsquic_conn_param param,
+                                      const void *value, size_t value_len);
+
+/**
+ * Get a connection parameter.
+ *
+ * @param conn       Connection object
+ * @param param      Parameter to get (from enum lsquic_conn_param)
+ * @param value      Pointer to buffer for value
+ * @param value_len  Pointer to size; on input, buffer size;
+ *                   on output, actual value size
+ * @return           0 on success, -1 on error
+ *
+ * Example:
+ *   uint64_t max_rate;
+ *   size_t len = sizeof(max_rate);
+ *   lsquic_conn_get_param(conn, LSQCP_MAX_PACING_RATE,
+ *                         &max_rate, &len);
+ */
+int
+lsquic_conn_get_param (lsquic_conn_t *conn, enum lsquic_conn_param param,
+                                          void *value, size_t *value_len);
 
 /**
  * Helper function: convert list of versions as specified in the argument

--- a/src/liblsquic/lsquic_conn.c
+++ b/src/liblsquic/lsquic_conn.c
@@ -346,3 +346,27 @@ lsquic_conn_get_info (lsquic_conn_t *lconn, struct lsquic_conn_info *info)
     return -1;
 }
 
+
+int
+lsquic_conn_set_param (lsquic_conn_t *lconn, enum lsquic_conn_param param,
+                                           const void *value, size_t value_len)
+{
+    if (!lconn || !value)
+        return -1;
+    if (lconn->cn_if && lconn->cn_if->ci_set_param)
+        return lconn->cn_if->ci_set_param(lconn, param, value, value_len);
+    return -1;
+}
+
+
+int
+lsquic_conn_get_param (lsquic_conn_t *lconn, enum lsquic_conn_param param,
+                                               void *value, size_t *value_len)
+{
+    if (!lconn || !value || !value_len)
+        return -1;
+    if (lconn->cn_if && lconn->cn_if->ci_get_param)
+        return lconn->cn_if->ci_get_param(lconn, param, value, value_len);
+    return -1;
+}
+

--- a/src/liblsquic/lsquic_conn.h
+++ b/src/liblsquic/lsquic_conn.h
@@ -297,6 +297,16 @@ struct conn_iface
     int
     (*ci_get_info) (lsquic_conn_t *conn, struct lsquic_conn_info *info);
 
+    /* Optional: set connection parameter */
+    int
+    (*ci_set_param) (lsquic_conn_t *conn, enum lsquic_conn_param param,
+                     const void *value, size_t value_len);
+
+    /* Optional: get connection parameter */
+    int
+    (*ci_get_param) (lsquic_conn_t *conn, enum lsquic_conn_param param,
+                     void *value, size_t *value_len);
+
     /* Used by the stream module to report that one of the user streams has
      * been read from or written to.  This is what underpins the "no progress
      * timeout" mechanism: see @ref es_noprogress_timeout.

--- a/src/liblsquic/lsquic_send_ctl.h
+++ b/src/liblsquic/lsquic_send_ctl.h
@@ -145,6 +145,7 @@ typedef struct lsquic_send_ctl {
     unsigned                        sc_square_count;/* Used to set square bit */
     unsigned                        sc_reord_thresh;
     signed char                     sc_cidlen;      /* For debug purposes */
+    uint64_t                        sc_max_pacing_rate; /* 0 = no override */
 } lsquic_send_ctl_t;
 
 void


### PR DESCRIPTION
This commit introduces a new API for controlling QUIC connection bandwidth at runtime on a per-connection basis.  Applications can now set maximum pacing rates independently for each connection using lsquic_conn_set_param() and lsquic_conn_get_param() functions with the LSQCP_MAX_PACING_RATE parameter.  Setting a non-zero value limits the connection's send rate in bytes per second regardless of what the congestion control algorithm calculates, while zero removes the limit.