### PR TITLE
Release 4.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,17 @@
+2025-12-01
+    - 4.4.0
+    - [API] Add per-connection send rate throttling.
+    - [BUGFIX] Fix data corruption in delayed mini-conn packets (#593).
+    - [BUGFIX] Allow split buffered packet to generate one packet. (This
+      can happen when DPLPMTUD increases a path's MTU.)  (#505).
+    - [BUGFIX] HTTP/3 client GOAWAY frame generation (#343).
+    - [TUNING] QUIC Interop: add zerortt support.
+    - Improve logs in the Extensible HTTP/3 Priority (HPI) module.
+    - Comment cleanup: update QUIC draft references to RFC references.
+    - Teach http_client to send "priority" header.
+    - Parallelize unit tests so that they finish faster.
+    - Include QUIC Interop Runner docker files in the distribution.
+
 2025-11-01
     - 4.3.2
     - [BUGFIX] Fix the no-progress timeout logic (issue #531, PR #574).

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-2025-12-01
+2024-12-01
     - 4.4.0
     - [API] Add per-connection send rate throttling.
     - [BUGFIX] Fix data corruption in delayed mini-conn packets (#593).

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -39,6 +39,7 @@ to the LiteSpeed QUIC and HTTP/3 Library:
     - Rylie Pavlik -- CMake improvements
     - davidlei -- Build improvements
     - Timo Voelker -- Testing and bug reports
+    - Kirill Sabitov -- Bug fixes
 
 Thank you!
 

--- a/bin/test_common.c
+++ b/bin/test_common.c
@@ -2435,6 +2435,13 @@ test_reader_read (void *void_ctx, void *buf, size_t count)
 struct reader_ctx *
 create_lsquic_reader_ctx (const char *filename)
 {
+    return create_lsquic_reader_ctx_max_bytes(filename, 0);
+}
+
+
+struct reader_ctx *
+create_lsquic_reader_ctx_max_bytes (const char *filename, size_t max_bytes)
+{
     int fd;
     struct stat st;
 
@@ -2457,6 +2464,8 @@ create_lsquic_reader_ctx (const char *filename)
     }
     struct reader_ctx *ctx = malloc(sizeof(*ctx));
     ctx->file_size = st.st_size;
+    if (max_bytes > 0 && max_bytes < ctx->file_size)
+        ctx->file_size = max_bytes;
     ctx->nread = 0;
     ctx->fd = fd;
     return ctx;

--- a/bin/test_common.h
+++ b/bin/test_common.h
@@ -135,6 +135,9 @@ test_reader_read (void *void_ctx, void *buf, size_t count);
 struct reader_ctx *
 create_lsquic_reader_ctx (const char *filename);
 
+struct reader_ctx *
+create_lsquic_reader_ctx_max_bytes (const char *filename, size_t max_bytes);
+
 void
 destroy_lsquic_reader_ctx (struct reader_ctx *ctx);
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = u'2023, LiteSpeed Technologies'
 author = u'LiteSpeed Technologies'
 
 # The short X.Y version
-version = u'4.3'
+version = u'4.4'
 # The full version, including alpha/beta/rc tags
-release = u'4.3.2'
+release = u'4.4.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -26,8 +26,8 @@ extern "C" {
 #endif
 
 #define LSQUIC_MAJOR_VERSION 4
-#define LSQUIC_MINOR_VERSION 3
-#define LSQUIC_PATCH_VERSION 2
+#define LSQUIC_MINOR_VERSION 4
+#define LSQUIC_PATCH_VERSION 0
 
 #define LSQUIC_QUOTE(x)     #x
 #define LSQUIC_SVAL(v)      LSQUIC_QUOTE(v)

--- a/qir/Dockerfile.build
+++ b/qir/Dockerfile.build
@@ -1,0 +1,36 @@
+FROM ubuntu:20.04 AS builder
+ENV  DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y apt-utils && \
+    apt-get install -y build-essential git cmake software-properties-common \
+                       zlib1g-dev libevent-dev
+
+RUN add-apt-repository ppa:longsleep/golang-backports && \
+    apt-get update && \
+    apt-get install -y golang-1.21-go && \
+    cp /usr/lib/go-1.21/bin/go* /usr/bin/.
+
+ENV GOROOT /usr/lib/go-1.21
+
+RUN mkdir /src
+WORKDIR /src
+
+RUN mkdir /src/lsquic
+COPY ./ /src/lsquic/
+
+RUN git clone https://github.com/google/boringssl.git && \
+    cd boringssl && \
+    git checkout 9fc1c33e9c21439ce5f87855a6591a9324e569fd && \
+    cmake . && \
+    make
+
+ENV EXTRA_CFLAGS -DLSQUIC_QIR=1
+RUN cd /src/lsquic && \
+    cmake -DBORINGSSL_DIR=/src/boringssl . && \
+    make -j http_client http_server
+
+RUN cp lsquic/bin/http_client /usr/bin/ && cp lsquic/bin/http_server /usr/bin
+
+FROM ubuntu:20.04
+COPY --from=builder /usr/bin/http_client /usr/bin/http_server /usr/bin/

--- a/qir/Dockerfile.final
+++ b/qir/Dockerfile.final
@@ -1,0 +1,5 @@
+FROM martenseemann/quic-network-simulator-endpoint:latest
+COPY --from=build-lsquic /usr/bin/http_client /usr/bin/http_server /usr/bin/
+COPY qir/run_endpoint.sh .
+RUN chmod +x run_endpoint.sh
+ENTRYPOINT [ "./run_endpoint.sh" ]

--- a/qir/README.txt
+++ b/qir/README.txt
@@ -1,0 +1,40 @@
+# Copyright (c) 2017 - 2022 LiteSpeed Technologies Inc.  See LICENSE.
+This directory contains files necessary to build Docker container
+for use with the QUIC Interop Runner [a].
+
+Build Instructions
+------------------
+
+1. Generate source tarball. No longer needed.
+
+The source tarball is what Docker will use to build the image.
+To generate the tarball, we use git-archive-all program as
+follows:
+
+    sh$ git-archive-all -C $LSQUIC_REPO_PATH --prefix=lsquic lsquic.tar
+
+git-archive-all can be installed via pip
+    pip/pip3 install git-archive-all
+
+2. Build the builder image.
+
+This image is based on Ubuntu 20 and in the end will contain
+compiled lsquic server and client programs, http_server and
+http_client.
+
+The purpose of this Docker image is to be used as the source
+for these binaries when building the final image.
+
+    sh$ docker build -f qir/Dockerfile.build -t build-lsquic .
+
+3. Build the final image.
+
+The final image combines the lsquic binaries and run_endpoint.sh
+script, which is where the magic (or, to be frank, hairy hackery)
+happens to run lsquic server and client based on environment
+variables set by the QUIC Interop Runner.
+
+    sh$ docker build -f qir/Dockerfile.final -t try-lsquic .
+
+
+a. https://github.com/marten-seemann/quic-interop-runner

--- a/qir/run_endpoint.sh
+++ b/qir/run_endpoint.sh
@@ -112,7 +112,7 @@ elif [ "$ROLE" = client ]; then
                 VERSIONS='-o version=h3 -Q hq-interop'
                 ECN='-o ecn=1'
                 ;;
-            resumption)
+            resumption|zerortt)
                 VERSIONS='-o version=h3 -Q hq-interop'
                 RESUME='-0 /logs/resume.file'
                 ;;
@@ -120,16 +120,16 @@ elif [ "$ROLE" = client ]; then
         esac
     fi
     echo CLIENT_PARAMS: $CLIENT_PARAMS
-    if [ "$TESTCASE" = resumption ]; then
+    if [ "$TESTCASE" = resumption ] || [ "$TESTCASE" = zerortt ]; then
         # Fetch first file:
         /usr/bin/http_client $VERSIONS -s $SERVER:$PORT $PATHS \
             -r 1 -R 1 $RESUME \
             -B -7 /downloads -G /logs \
             -L debug 2>/logs/$TESTCASE-req1.out || exit $?
         PATHS=`echo "$PATHS" | sed 's~-p /[^ ]* ~~'`
-        N_REQS=1
-        N_reqs=1
-        W=1
+        ((--N_REQS))
+        ((--N_reqs))
+        W=$N_reqs
         echo "first request successful, new args: $N_REQS; $N_reqs; $PATHS"
     fi
     /usr/bin/http_client $VERSIONS -s $SERVER:$PORT $PATHS \


### PR DESCRIPTION
- [API] Add per-connection send rate throttling.
- [BUGFIX] Fix data corruption in delayed mini-conn packets (#593).
- [BUGFIX] Allow split buffered packet to generate one packet. (This can happen when DPLPMTUD increases a path's MTU.)  (#505).
- [BUGFIX] HTTP/3 client GOAWAY frame generation (#343).
- [TUNING] QUIC Interop: add zerortt support.
- Improve logs in the Extensible HTTP/3 Priority (HPI) module.
- Comment cleanup: update QUIC draft references to RFC references.
- Teach http_client to send "priority" header.
- Parallelize unit tests so that they finish faster.
- Include QUIC Interop Runner docker files in the distribution.