### PR TITLE
Release 4.4.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,9 @@
-2024-12-01
+2025-12-07
+    - 4.4.1
+    - [IMPROVEMENT] Improve BBR performance at high BDP by removing a
+      hardcoded limit inherited from the original BBR code in Chrome.
+
+2025-11-30
     - 4.4.0
     - [API] Add per-connection send rate throttling.
     - [BUGFIX] Fix data corruption in delayed mini-conn packets (#593).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = u'LiteSpeed Technologies'
 # The short X.Y version
 version = u'4.4'
 # The full version, including alpha/beta/rc tags
-release = u'4.4.0'
+release = u'4.4.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #define LSQUIC_MAJOR_VERSION 4
 #define LSQUIC_MINOR_VERSION 4
-#define LSQUIC_PATCH_VERSION 0
+#define LSQUIC_PATCH_VERSION 1
 
 #define LSQUIC_QUOTE(x)     #x
 #define LSQUIC_SVAL(v)      LSQUIC_QUOTE(v)


### PR DESCRIPTION
- [IMPROVEMENT] Improve BBR performance at high BDP by removing a hardcoded limit inherited from the original BBR code in Chrome.