### PR TITLE
Release 4.5.0 - improve bandwidth estimate

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2026-01-11
+    - 4.5.0
+    - [API] Expose lci_pacing_rate in lsquic_conn_info
+    - [IMPROVEMENT] Bandwidth estimate provided in lsquic_conn_info.
+
 2026-01-04
     - 4.4.2
     - [BUGFIX] BBR: mark connections app-limited when pacing is capped and

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -1997,6 +1997,76 @@ Miscellaneous Connection Functions
 
     Get connection status.
 
+.. type:: struct lsquic_conn_info
+
+    Connection statistics snapshot returned by
+    :func:`lsquic_conn_get_info()`.
+
+    .. member:: uint32_t lci_cwnd
+
+        Current congestion window, in bytes.
+
+    .. member:: uint32_t lci_pmtu
+
+        Path MTU in bytes.
+
+    .. member:: uint32_t lci_rtt
+
+        Smoothed RTT in microseconds.
+
+    .. member:: uint32_t lci_rttvar
+
+        RTT variation in microseconds.
+
+    .. member:: uint32_t lci_rtt_min
+
+        Minimum RTT in microseconds.
+
+    .. member:: uint64_t lci_bytes_rcvd
+
+        Total bytes received.
+
+    .. member:: uint64_t lci_bytes_sent
+
+        Total bytes sent.
+
+    .. member:: uint64_t lci_pkts_rcvd
+
+        Total packets received.
+
+    .. member:: uint64_t lci_pkts_sent
+
+        Total packets sent.
+
+    .. member:: uint64_t lci_pkts_lost
+
+        Total packets lost.
+
+    .. member:: uint64_t lci_pkts_retx
+
+        Total packets retransmitted.
+
+    .. member:: uint64_t lci_pacing_rate
+
+        Current pacing rate (bytes per second) as computed by the
+        congestion controller.
+
+    .. member:: uint64_t lci_bw_estimate
+
+        Bandwidth estimate (bits per second) derived from recent samples.
+
+    .. member:: uint64_t lci_max_pacing_rate
+
+        Maximum pacing rate limit (bytes per second), or 0 if not set.
+
+.. function:: int lsquic_conn_get_info (lsquic_conn_t *conn, struct lsquic_conn_info *info)
+
+    Populate :type:`lsquic_conn_info` with a snapshot of connection stats.
+
+    :param conn: Connection object
+    :param info: Pointer to :type:`lsquic_conn_info` to fill in
+    :return: 0 on success, -1 on error
+
 Connection Parameters
 ---------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = u'2023, LiteSpeed Technologies'
 author = u'LiteSpeed Technologies'
 
 # The short X.Y version
-version = u'4.4'
+version = u'4.5'
 # The full version, including alpha/beta/rc tags
-release = u'4.4.2'
+release = u'4.5.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -26,8 +26,8 @@ extern "C" {
 #endif
 
 #define LSQUIC_MAJOR_VERSION 4
-#define LSQUIC_MINOR_VERSION 4
-#define LSQUIC_PATCH_VERSION 2
+#define LSQUIC_MINOR_VERSION 5
+#define LSQUIC_PATCH_VERSION 0
 
 #define LSQUIC_QUOTE(x)     #x
 #define LSQUIC_SVAL(v)      LSQUIC_QUOTE(v)
@@ -2154,6 +2154,7 @@ struct lsquic_conn_info
     uint64_t lci_pkts_retx;
     uint64_t lci_bw_estimate;
     uint64_t lci_max_pacing_rate;
+    uint64_t lci_pacing_rate;
 };
 
 int

--- a/src/liblsquic/lsquic_adaptive_cc.c
+++ b/src/liblsquic/lsquic_adaptive_cc.c
@@ -57,12 +57,11 @@
 
 
 static void
-adaptive_cc_init (void *cong_ctl, const struct lsquic_conn_public *conn_pub,
-                                                enum quic_ft_bit retx_frames)
+adaptive_cc_init (void *cong_ctl, const struct lsquic_conn_public *conn_pub)
 {
     struct adaptive_cc *const acc = cong_ctl;
 
-    CALL_BOTH(cci_init, conn_pub, retx_frames);
+    CALL_BOTH(cci_init, conn_pub);
     LSQ_DEBUG("initialized");
 }
 
@@ -193,6 +192,14 @@ adaptive_cc_cleanup (void *cong_ctl)
     LSQ_DEBUG("cleanup");
 }
 
+static void
+adaptive_cc_process_bw_sample (void *cong_ctl, struct bw_sample *sample)
+{
+    struct adaptive_cc *const acc = cong_ctl;
+
+    CALL_BOTH_MAYBE(cci_process_bw_sample, sample);
+}
+
 
 const struct cong_ctl_if lsquic_cong_adaptive_if =
 {
@@ -208,5 +215,6 @@ const struct cong_ctl_if lsquic_cong_adaptive_if =
     .cci_reinit        = adaptive_cc_reinit,
     .cci_timeout       = adaptive_cc_timeout,
     .cci_sent          = adaptive_cc_sent,
+    .cci_process_bw_sample = adaptive_cc_process_bw_sample,
     .cci_was_quiet     = adaptive_cc_was_quiet,
 };

--- a/src/liblsquic/lsquic_bbr.h
+++ b/src/liblsquic/lsquic_bbr.h
@@ -92,7 +92,7 @@ struct lsquic_bbr
     const struct lsquic_rtt_stats
                                *bbr_rtt_stats;
 
-    struct bw_sampler           bbr_bw_sampler;
+    uint64_t                    bbr_total_acked;
 
     /*
      " BBR.BtlBwFilter: The max filter used to estimate BBR.BtlBw.
@@ -199,7 +199,6 @@ struct lsquic_bbr
         lsquic_packno_t     max_packno;
         uint64_t            acked_bytes;
         uint64_t            lost_bytes;
-        uint64_t            total_bytes_acked_before;
         uint64_t            in_flight;
         int                 has_losses;
     }                           bbr_ack_state;

--- a/src/liblsquic/lsquic_bw_sampler.h
+++ b/src/liblsquic/lsquic_bw_sampler.h
@@ -42,6 +42,10 @@ struct bw_sampler
      */
     lsquic_time_t       bws_last_acked_sent_time;
     lsquic_time_t       bws_last_acked_packet_time;
+    /* For bandwidth calculation: track acked bytes over a time window */
+    uint64_t            bws_bw_calc_acked;
+    lsquic_time_t       bws_bw_calc_time;
+    uint64_t            bws_last_bw;        /* Last calculated bandwidth */
     lsquic_packno_t     bws_last_sent_packno;
     lsquic_packno_t     bws_end_of_app_limited_phase;
     struct malo        *bws_malo;   /* For struct osp_state objects */
@@ -82,6 +86,9 @@ lsquic_bw_sampler_app_limited (struct bw_sampler *);
 
 void
 lsquic_bw_sampler_cleanup (struct bw_sampler *);
+
+uint64_t
+lsquic_bw_sampler_get_bw (struct bw_sampler *);
 
 unsigned
 lsquic_bw_sampler_entry_count (const struct bw_sampler *);

--- a/src/liblsquic/lsquic_cong_ctl.h
+++ b/src/liblsquic/lsquic_cong_ctl.h
@@ -9,6 +9,7 @@
 
 struct lsquic_conn_public;
 struct lsquic_packet_out;
+struct bw_sample;
 enum quic_ft_bit;
 
 
@@ -20,8 +21,7 @@ enum quic_ft_bit;
 struct cong_ctl_if
 {
     void
-    (*cci_init) (void *cong_ctl, const struct lsquic_conn_public *,
-                                                            enum quic_ft_bit);
+    (*cci_init) (void *cong_ctl, const struct lsquic_conn_public *);
 
     void
     (*cci_reinit) (void *cong_ctl);
@@ -51,6 +51,10 @@ struct cong_ctl_if
     void
     (*cci_lost) (void *cong_ctl, struct lsquic_packet_out *,
                                                         unsigned packet_sz);
+
+    /* Optional method */
+    void
+    (*cci_process_bw_sample) (void *cong_ctl, struct bw_sample *);
 
     void
     (*cci_timeout) (void *cong_ctl);

--- a/src/liblsquic/lsquic_cubic.c
+++ b/src/liblsquic/lsquic_cubic.c
@@ -115,8 +115,7 @@ lsquic_cubic_set_flags (struct lsquic_cubic *cubic, enum cubic_flags flags)
 
 
 static void
-lsquic_cubic_init (void *cong_ctl, const struct lsquic_conn_public *conn_pub,
-                                            enum quic_ft_bit UNUSED_retx_frames)
+lsquic_cubic_init (void *cong_ctl, const struct lsquic_conn_public *conn_pub)
 {
     struct lsquic_cubic *const cubic = cong_ctl;
     cubic_reset(cubic);

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -9063,8 +9063,9 @@ ietf_full_conn_ci_get_info (lsquic_conn_t *lconn, struct lsquic_conn_info *info)
     info->lci_rttvar = lsquic_rtt_stats_get_rttvar(&conn->ifc_pub.rtt_stats);
     info->lci_rtt_min = lsquic_rtt_stats_get_min_rtt(&conn->ifc_pub.rtt_stats);
     info->lci_pmtu = conn->ifc_paths[conn->ifc_cur_path_id].cop_path.np_pack_size;
-    info->lci_bw_estimate = conn->ifc_send_ctl.sc_ci->cci_pacing_rate(
+    info->lci_pacing_rate = conn->ifc_send_ctl.sc_ci->cci_pacing_rate(
                                             conn->ifc_send_ctl.sc_cong_ctl, 1);
+    info->lci_bw_estimate = lsquic_send_ctl_get_bw(&conn->ifc_send_ctl);
     info->lci_max_pacing_rate = conn->ifc_send_ctl.sc_max_pacing_rate;
 
 #if LSQUIC_CONN_STATS

--- a/src/liblsquic/lsquic_send_ctl.h
+++ b/src/liblsquic/lsquic_send_ctl.h
@@ -54,6 +54,8 @@ enum send_ctl_flags {
     SC_ACK_RECV_HSK =  SC_ACK_RECV_INIT << PNS_HSK,
     SC_ACK_RECV_APP =  SC_ACK_RECV_INIT << PNS_APP,
     SC_ROUGH_RTT    =  1 << 22,
+    SC_BW_SAMPLER_INIT = 1 << 23, /* bw_sampler is initialized */
+    SC_BW_SAMPLER_INFO = 1 << 24, /* bandwidth info was requested */
 #if LSQUIC_DEVEL
     SC_DYN_PTHRESH  =  1 << 31u,    /* dynamic packet threshold enabled */
 #endif
@@ -97,6 +99,7 @@ typedef struct lsquic_send_ctl {
     const struct ver_neg           *sc_ver_neg;
     struct lsquic_conn_public      *sc_conn_pub;
     struct pacer                    sc_pacer;
+    struct bw_sampler               sc_bw_sampler;
     lsquic_packno_t                 sc_cur_packno;
     lsquic_packno_t                 sc_largest_sent_at_cutback;
     lsquic_packno_t                 sc_max_rtt_packno;
@@ -519,5 +522,8 @@ lsquic_send_ctl_0rtt_to_1rtt (struct lsquic_send_ctl *);
 
 void
 lsquic_send_ctl_stash_0rtt_packets (struct lsquic_send_ctl *);
+
+uint64_t
+lsquic_send_ctl_get_bw (struct lsquic_send_ctl *);
 
 #endif

--- a/tests/graph_cubic.c
+++ b/tests/graph_cubic.c
@@ -74,7 +74,7 @@ main (int argc, char **argv)
     enum cubic_flags flags;
     struct lsquic_packet_out packet_out;
 
-    cci->cci_init(&cubic, 0, 0);
+    cci->cci_init(&cubic, 0);
     max_cwnd = 0;
     i = 0;
     memset(&packet_out, 0, sizeof(packet_out));

--- a/tests/test_cubic.c
+++ b/tests/test_cubic.c
@@ -41,7 +41,7 @@ test_post_quiescence_explosion (void)
     int i;
     struct lsquic_packet_out packet_out; memset(&packet_out, 0, sizeof(packet_out));
 
-    cci->cci_init(&cubic, &conn_pub, 0);
+    cci->cci_init(&cubic, &conn_pub);
     cubic.cu_ssthresh = cubic.cu_cwnd = 32 * 1370;
 
     for (i = 0; i < 10; ++i)
@@ -75,7 +75,7 @@ test_post_quiescence_explosion2 (void)
     int i;
     struct lsquic_packet_out packet_out; memset(&packet_out, 0, sizeof(packet_out));
 
-    cci->cci_init(&cubic, &conn_pub, 0);
+    cci->cci_init(&cubic, &conn_pub);
     cubic.cu_ssthresh = cubic.cu_cwnd = 32 * 1370;
 
     for (i = 0; i < 10; ++i)


### PR DESCRIPTION
The bandwidth sampler used by the BBR controller has been extracted so that it can be used by the send controller directly.  Because bandwidth sampling is not free, some care is taken to sample only when necessary: either a) BBR is used or b) lsquic_conn_get_info() has been called.

The value previously exposed as lci_bw_estimate is now lci_pacing_rate.