### PR TITLE
Release 4.6.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2026-02-20
+    - 4.6.0
+    - [API] Allow to optimize BW sampler use.
+    - [FIX] Crash in the new bandwidth estimate code.
+    - [IMPROVEMENT] Transport param checks warnings (gcc 14).
+
 2026-01-11
     - 4.5.0
     - [API] Expose lci_pacing_rate in lsquic_conn_info

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -731,6 +731,23 @@ settings structure:
 
        The default value is :macro:`LSQUIC_DF_CC_RTT_THRESH`
 
+    .. member:: int             es_enable_bw_sampler
+
+       If you plan to call :func:`lsquic_conn_get_info()`, set this to true.
+
+       This causes bandwidth sampler to be initialized even when selected
+       congestion controller does not need it.  This way, bandwidth estimate
+       is available on the first call to :func:`lsquic_conn_get_info()`.
+
+       If false, first :func:`lsquic_conn_get_info()` call may initialize
+       sampler and bandwidth estimate may only be available on subsequent
+       call.
+
+       This can be overridden per connection using
+       :member:`LSQCP_ENABLE_BW_SAMPLER`.
+
+       The default value is :macro:`LSQUIC_DF_ENABLE_BW_SAMPLER`
+
     .. member:: int             es_ql_bits
 
        Use QL loss bits.  Allowed values are:
@@ -2098,6 +2115,25 @@ available through engine settings.
         Setting this value to 0 removes the limit, allowing the congestion control
         algorithm to determine the send rate.
 
+    .. member:: LSQCP_ENABLE_BW_SAMPLER
+
+        If you plan to call :func:`lsquic_conn_get_info()`, set this value
+        to true.
+
+        **Type:** ``int``
+
+        **Default:** inherited from :member:`lsquic_engine_settings.es_enable_bw_sampler`
+
+        This causes bandwidth sampler to be initialized even when selected
+        congestion controller does not need it.  This way, bandwidth estimate
+        is available on the first call to :func:`lsquic_conn_get_info()`.
+
+        If false, first :func:`lsquic_conn_get_info()` call may initialize
+        sampler and bandwidth estimate may only be available on subsequent
+        call.
+
+        **Note:** :func:`lsquic_conn_get_info()` enables the sampler if needed.
+
 .. function:: int lsquic_conn_set_param (lsquic_conn_t *conn, enum lsquic_conn_param param, const void *value, size_t value_len)
 
     Set a connection parameter.
@@ -2129,6 +2165,14 @@ available through engine settings.
         uint64_t unlimited = 0;
         lsquic_conn_set_param(conn, LSQCP_MAX_PACING_RATE,
                               &unlimited, sizeof(unlimited));
+
+    **Example - Enabling bandwidth sampler for this connection:**
+
+    ::
+
+        int on = 1;
+        lsquic_conn_set_param(conn, LSQCP_ENABLE_BW_SAMPLER,
+                              &on, sizeof(on));
 
     **Note:** For :member:`LSQCP_MAX_PACING_RATE`, pacing must be enabled
     via :member:`lsquic_engine_settings.es_pace_packets` for this parameter

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = u'2023, LiteSpeed Technologies'
 author = u'LiteSpeed Technologies'
 
 # The short X.Y version
-version = u'4.5'
+version = u'4.6'
 # The full version, including alpha/beta/rc tags
-release = u'4.5.0'
+release = u'4.6.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 #define LSQUIC_MAJOR_VERSION 4
-#define LSQUIC_MINOR_VERSION 5
+#define LSQUIC_MINOR_VERSION 6
 #define LSQUIC_PATCH_VERSION 0
 
 #define LSQUIC_QUOTE(x)     #x
@@ -418,6 +418,9 @@ typedef struct ssl_ctx_st * (*lsquic_lookup_cert_f)(
 /* Default value of the CC RTT threshold is 1.5 ms */
 #define LSQUIC_DF_CC_RTT_THRESH 1500
 
+/* By default, bandwidth sampler is not kept alive unless requested. */
+#define LSQUIC_DF_ENABLE_BW_SAMPLER 0
+
 /** Turn off datagram extension by default */
 #define LSQUIC_DF_DATAGRAMS 0
 
@@ -739,6 +742,23 @@ struct lsquic_engine_settings {
      * The default value is @ref LSQUIC_DF_CC_RTT_THRESH.
      */
     unsigned        es_cc_rtt_thresh;
+
+    /**
+     * If you plan to call lsquic_conn_get_info(), set this to true.
+     *
+     * This causes bandwidth sampler to be initialized even when selected
+     * congestion controller does not need it.  This way, bandwidth estimate
+     * is available on the first call to lsquic_conn_get_info().
+     *
+     * If false, first lsquic_conn_get_info() call may initialize sampler and
+     * bandwidth estimate may only be available on subsequent call.
+     *
+     * This can be overridden per connection at runtime using
+     * lsquic_conn_set_param(..., LSQCP_ENABLE_BW_SAMPLER, ...).
+     *
+     * The default value is @ref LSQUIC_DF_ENABLE_BW_SAMPLER.
+     */
+    int             es_enable_bw_sampler;
 
     /**
      * No progress timeout.
@@ -2137,6 +2157,22 @@ enum lsquic_conn_param
      * Pacing must be turned on via es_pace_packets in lsquic_engine_settings.
      */
     LSQCP_MAX_PACING_RATE = 1,
+    /**
+     * If you plan to call lsquic_conn_get_info(), set this value to true.
+     *
+     * Type: int
+     * Default: inherited from es_enable_bw_sampler.
+     *
+     * This causes bandwidth sampler to be initialized even when selected
+     * congestion controller does not need it.  This way, bandwidth estimate
+     * is available on the first call to lsquic_conn_get_info().
+     *
+     * If false, first lsquic_conn_get_info() call may initialize sampler and
+     * bandwidth estimate may only be available on subsequent call.
+     *
+     * lsquic_conn_get_info() enables sampling if needed for functionality.
+     */
+    LSQCP_ENABLE_BW_SAMPLER = 2,
 };
 
 struct lsquic_conn_info

--- a/src/liblsquic/lsquic_bw_sampler.c
+++ b/src/liblsquic/lsquic_bw_sampler.c
@@ -3,6 +3,7 @@
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 #include <sys/queue.h>
 
 #include "lsquic_int_types.h"
@@ -63,6 +64,7 @@ lsquic_bw_sampler_cleanup (struct bw_sampler *sampler)
         lsquic_malo_destroy(sampler->bws_malo);
         sampler->bws_malo = NULL;
     }
+    memset(sampler, 0, sizeof(*sampler));
 }
 
 

--- a/src/liblsquic/lsquic_enc_sess_ietf.c
+++ b/src/liblsquic/lsquic_enc_sess_ietf.c
@@ -1519,7 +1519,7 @@ iquic_ssl_sess_to_resume_info (struct enc_sess_iquic *enc_sess, SSL *ssl,
     size_t trapa_sz, buf_sz;
 
     SSL_get_peer_quic_transport_params(ssl, &trapa_buf, &trapa_sz);
-    if (!(trapa_buf + trapa_sz))
+    if (!trapa_buf || !trapa_sz)
     {
         LSQ_WARN("no transport parameters: cannot generate session "
                                                     "resumption info");
@@ -1735,7 +1735,7 @@ get_peer_transport_params (struct enc_sess_iquic *enc_sess)
     int have_0rtt_tp;
 
     SSL_get_peer_quic_transport_params(enc_sess->esi_ssl, &params_buf, &bufsz);
-    if (!params_buf)
+    if (!params_buf || !bufsz)
     {
         LSQ_DEBUG("no peer transport parameters");
         return -1;

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -391,6 +391,7 @@ lsquic_engine_init_settings (struct lsquic_engine_settings *settings,
     settings->es_dplpmtud        = LSQUIC_DF_DPLPMTUD;
     settings->es_cc_algo         = LSQUIC_DF_CC_ALGO;
     settings->es_cc_rtt_thresh   = LSQUIC_DF_CC_RTT_THRESH;
+    settings->es_enable_bw_sampler = LSQUIC_DF_ENABLE_BW_SAMPLER;
     settings->es_optimistic_nat  = LSQUIC_DF_OPTIMISTIC_NAT;
     settings->es_ext_http_prio   = LSQUIC_DF_EXT_HTTP_PRIO;
     settings->es_ptpc_periodicity= LSQUIC_DF_PTPC_PERIODICITY;

--- a/src/liblsquic/lsquic_full_conn.c
+++ b/src/liblsquic/lsquic_full_conn.c
@@ -4550,6 +4550,7 @@ full_conn_ci_set_param (lsquic_conn_t *lconn, enum lsquic_conn_param param,
 {
     struct full_conn *conn = (struct full_conn *) lconn;
     uint64_t rate;
+    int enable_bw_sampler;
 
     switch (param)
     {
@@ -4559,6 +4560,14 @@ full_conn_ci_set_param (lsquic_conn_t *lconn, enum lsquic_conn_param param,
         memcpy(&rate, value, sizeof(rate));
         conn->fc_send_ctl.sc_max_pacing_rate = rate;
         LSQ_INFO("max pacing rate set to %"PRIu64" bps", rate);
+        return 0;
+    case LSQCP_ENABLE_BW_SAMPLER:
+        if (value_len != sizeof(int))
+            return -1;
+        memcpy(&enable_bw_sampler, value, sizeof(enable_bw_sampler));
+        lsquic_send_ctl_set_bw_sampler(&conn->fc_send_ctl, enable_bw_sampler);
+        LSQ_INFO("bw sampler %s",
+                 enable_bw_sampler ? "enabled" : "disabled");
         return 0;
     default:
         return -1;
@@ -4572,16 +4581,24 @@ full_conn_ci_get_param (lsquic_conn_t *lconn, enum lsquic_conn_param param,
 {
     struct full_conn *conn = (struct full_conn *) lconn;
     uint64_t rate;
-
-    if (*value_len < sizeof(uint64_t))
-        return -1;
+    int enable_bw_sampler;
 
     switch (param)
     {
     case LSQCP_MAX_PACING_RATE:
+        if (*value_len < sizeof(uint64_t))
+            return -1;
         rate = conn->fc_send_ctl.sc_max_pacing_rate;
         memcpy(value, &rate, sizeof(rate));
         *value_len = sizeof(rate);
+        return 0;
+    case LSQCP_ENABLE_BW_SAMPLER:
+        if (*value_len < sizeof(int))
+            return -1;
+        enable_bw_sampler =
+                lsquic_send_ctl_bw_sampler_enabled(&conn->fc_send_ctl);
+        memcpy(value, &enable_bw_sampler, sizeof(enable_bw_sampler));
+        *value_len = sizeof(enable_bw_sampler);
         return 0;
     default:
         return -1;

--- a/src/liblsquic/lsquic_send_ctl.h
+++ b/src/liblsquic/lsquic_send_ctl.h
@@ -55,7 +55,7 @@ enum send_ctl_flags {
     SC_ACK_RECV_APP =  SC_ACK_RECV_INIT << PNS_APP,
     SC_ROUGH_RTT    =  1 << 22,
     SC_BW_SAMPLER_INIT = 1 << 23, /* bw_sampler is initialized */
-    SC_BW_SAMPLER_INFO = 1 << 24, /* bandwidth info was requested */
+    SC_KEEP_BW_SAMPLER = 1 << 24, /* keep bw sampler for conn lifetime */
 #if LSQUIC_DEVEL
     SC_DYN_PTHRESH  =  1 << 31u,    /* dynamic packet threshold enabled */
 #endif
@@ -522,6 +522,12 @@ lsquic_send_ctl_0rtt_to_1rtt (struct lsquic_send_ctl *);
 
 void
 lsquic_send_ctl_stash_0rtt_packets (struct lsquic_send_ctl *);
+
+void
+lsquic_send_ctl_set_bw_sampler (struct lsquic_send_ctl *, int enable);
+
+int
+lsquic_send_ctl_bw_sampler_enabled (const struct lsquic_send_ctl *);
 
 uint64_t
 lsquic_send_ctl_get_bw (struct lsquic_send_ctl *);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ SET(TESTS
     rst_stream_gquic_be
     rtt
     send_headers
+    send_ctl_bw_lifecycle
     senhist
     set
     sfcw

--- a/tests/test_send_ctl_bw_lifecycle.c
+++ b/tests/test_send_ctl_bw_lifecycle.c
@@ -1,0 +1,331 @@
+/* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
+/* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/queue.h>
+
+#include "lsquic.h"
+#include "lsquic_int_types.h"
+#include "lsquic_types.h"
+#include "lsquic_packet_common.h"
+#include "lsquic_alarmset.h"
+#include "lsquic_conn_flow.h"
+#include "lsquic_rtt.h"
+#include "lsquic_sfcw.h"
+#include "lsquic_varint.h"
+#include "lsquic_hq.h"
+#include "lsquic_hash.h"
+#include "lsquic_stream.h"
+#include "lsquic_mm.h"
+#include "lsquic_conn_public.h"
+#include "lsquic_parse.h"
+#include "lsquic_conn.h"
+#include "lsquic_engine_public.h"
+#include "lsquic_cubic.h"
+#include "lsquic_pacer.h"
+#include "lsquic_senhist.h"
+#include "lsquic_bw_sampler.h"
+#include "lsquic_minmax.h"
+#include "lsquic_bbr.h"
+#include "lsquic_adaptive_cc.h"
+#include "lsquic_send_ctl.h"
+#include "lsquic_ver_neg.h"
+#include "lsquic_packet_out.h"
+#include "lsquic_malo.h"
+#include "lsquic_enc_sess.h"
+#include "lsquic_logger.h"
+
+
+struct bw_lifecycle_test
+{
+    struct lsquic_conn           lconn;
+    struct lsquic_engine_public  enpub;
+    struct lsquic_conn_public    conn_pub;
+    struct lsquic_send_ctl       send_ctl;
+    struct lsquic_alarmset       alset;
+    struct ver_neg               ver_neg;
+    struct network_path          path;
+};
+
+
+static void
+init_test (struct bw_lifecycle_test *t, unsigned cc_algo,
+           unsigned cc_rtt_thresh, int enable_bw_sampler)
+{
+    /* Build a minimal send_ctl environment with configurable CC policy. */
+    memset(t, 0, sizeof(*t));
+    LSCONN_INITIALIZE(&t->lconn);
+    t->lconn.cn_flags |= LSCONN_HANDSHAKE_DONE;
+    t->lconn.cn_version = LSQVER_043;
+    t->lconn.cn_pf = select_pf_by_ver(LSQVER_043);
+    t->lconn.cn_esf_c = &lsquic_enc_session_common_gquic_1;
+    lsquic_engine_init_settings(&t->enpub.enp_settings, 0);
+    t->enpub.enp_settings.es_cc_algo = cc_algo;
+    t->enpub.enp_settings.es_cc_rtt_thresh = cc_rtt_thresh;
+    t->enpub.enp_settings.es_enable_bw_sampler = !!enable_bw_sampler;
+    lsquic_mm_init(&t->enpub.enp_mm);
+    lsquic_alarmset_init(&t->alset, 0);
+    TAILQ_INIT(&t->conn_pub.sending_streams);
+    TAILQ_INIT(&t->conn_pub.read_streams);
+    TAILQ_INIT(&t->conn_pub.write_streams);
+    TAILQ_INIT(&t->conn_pub.service_streams);
+    t->path.np_pack_size = 1370;
+    t->conn_pub.mm = &t->enpub.enp_mm;
+    t->conn_pub.lconn = &t->lconn;
+    t->conn_pub.enpub = &t->enpub;
+    t->conn_pub.send_ctl = &t->send_ctl;
+    t->conn_pub.path = &t->path;
+    t->conn_pub.packet_out_malo =
+                        lsquic_malo_create(sizeof(struct lsquic_packet_out));
+    assert(t->conn_pub.packet_out_malo);
+    lsquic_send_ctl_init(&t->send_ctl, &t->alset, &t->enpub, &t->ver_neg,
+                                                     &t->conn_pub, 0);
+}
+
+
+static void
+cleanup_test (struct bw_lifecycle_test *t)
+{
+    /* Mirror init_test() teardown to keep each scenario independent. */
+    lsquic_send_ctl_cleanup(&t->send_ctl);
+    lsquic_malo_destroy(t->conn_pub.packet_out_malo);
+    lsquic_mm_cleanup(&t->enpub.enp_mm);
+}
+
+
+static struct lsquic_packet_out *
+new_packet (struct bw_lifecycle_test *t, lsquic_packno_t packno,
+            lsquic_time_t sent_time)
+{
+    /* Create one app-data packet eligible for sampler state attachment. */
+    struct lsquic_packet_out *packet_out;
+
+    packet_out = lsquic_mm_get_packet_out(&t->enpub.enp_mm, NULL, 64);
+    assert(packet_out);
+    packet_out->po_packno = packno;
+    packet_out->po_sent = sent_time;
+    packet_out->po_sent_sz = 1200;
+    packet_out->po_flags |= PO_HELLO|PO_SENT_SZ;
+    packet_out->po_frame_types = QUIC_FTBIT_STREAM;
+    packet_out->po_path = &t->path;
+    packet_out->po_loss_chain = packet_out;
+    lsquic_packet_out_set_pns(packet_out, PNS_APP);
+
+    return packet_out;
+}
+
+
+static void
+ack_one (struct bw_lifecycle_test *t, lsquic_packno_t packno,
+         lsquic_time_t ack_time, lsquic_time_t now, lsquic_time_t lack_delta)
+{
+    /* ACK exactly one APP packet to drive loss/CC transitions deterministically. */
+    struct ack_info acki;
+    memset(&acki, 0, sizeof(acki));
+    acki.pns = PNS_APP;
+    acki.n_ranges = 1;
+    acki.ranges[0].high = packno;
+    acki.ranges[0].low = packno;
+    acki.lack_delta = lack_delta;
+    assert(0 == lsquic_send_ctl_got_ack(&t->send_ctl, &acki, ack_time, now));
+}
+
+
+static void
+test_cubic_lazy_enable (void)
+{
+    /* Cubic starts without sampler; first get_bw() lazily enables it. */
+    struct bw_lifecycle_test t;
+    struct lsquic_packet_out *packet_out;
+
+    init_test(&t, 1, 100000, 0);
+
+    assert(t.send_ctl.sc_ci == &lsquic_cong_cubic_if);
+    assert(!(t.send_ctl.sc_flags & SC_BW_SAMPLER_INIT));
+
+    packet_out = new_packet(&t, 1, 1000);
+    assert(0 == lsquic_send_ctl_sent_packet(&t.send_ctl, packet_out));
+    assert(NULL == packet_out->po_bwp_state);
+
+    (void) lsquic_send_ctl_get_bw(&t.send_ctl);
+    assert(t.send_ctl.sc_flags & SC_KEEP_BW_SAMPLER);
+    assert(t.send_ctl.sc_flags & SC_BW_SAMPLER_INIT);
+
+    packet_out = new_packet(&t, 2, 2000);
+    assert(0 == lsquic_send_ctl_sent_packet(&t.send_ctl, packet_out));
+    assert(NULL != packet_out->po_bwp_state);
+
+    cleanup_test(&t);
+}
+
+
+static void
+test_adaptive_switch_without_info_drops_sampler (void)
+{
+    /* Adaptive->Cubic drops sampler unless explicitly kept for info collection. */
+    struct bw_lifecycle_test t;
+    struct lsquic_packet_out *packet_out;
+
+    init_test(&t, 3, 100000, 0);
+
+    assert(t.send_ctl.sc_ci == &lsquic_cong_adaptive_if);
+    assert(t.send_ctl.sc_flags & SC_BW_SAMPLER_INIT);
+    assert(!(t.send_ctl.sc_flags & SC_KEEP_BW_SAMPLER));
+
+    packet_out = new_packet(&t, 1, 1000);
+    assert(0 == lsquic_send_ctl_sent_packet(&t.send_ctl, packet_out));
+    assert(NULL != packet_out->po_bwp_state);
+
+    ack_one(&t, 1, 2000, 2000, 1);
+
+    assert(t.send_ctl.sc_ci == &lsquic_cong_cubic_if);
+    assert(!(t.send_ctl.sc_flags & SC_BW_SAMPLER_INIT));
+
+    cleanup_test(&t);
+}
+
+
+static void
+test_adaptive_switch_with_info_keeps_sampler (void)
+{
+    /* get_bw() marks sampler as keep-on; Adaptive->Cubic must preserve it. */
+    struct bw_lifecycle_test t;
+    struct lsquic_packet_out *packet_out;
+
+    init_test(&t, 3, 100000, 0);
+
+    (void) lsquic_send_ctl_get_bw(&t.send_ctl);
+    assert(t.send_ctl.sc_flags & SC_KEEP_BW_SAMPLER);
+    assert(t.send_ctl.sc_flags & SC_BW_SAMPLER_INIT);
+
+    packet_out = new_packet(&t, 1, 1000);
+    assert(0 == lsquic_send_ctl_sent_packet(&t.send_ctl, packet_out));
+    assert(NULL != packet_out->po_bwp_state);
+
+    ack_one(&t, 1, 2000, 2000, 1);
+
+    assert(t.send_ctl.sc_ci == &lsquic_cong_cubic_if);
+    assert(t.send_ctl.sc_flags & SC_BW_SAMPLER_INIT);
+
+    packet_out = new_packet(&t, 2, 3000);
+    assert(0 == lsquic_send_ctl_sent_packet(&t.send_ctl, packet_out));
+    assert(NULL != packet_out->po_bwp_state);
+
+    cleanup_test(&t);
+}
+
+
+static void
+test_drop_clears_inflight_packet_states (void)
+{
+    /* Sampler drop must clear per-packet sampler state left on inflight packets. */
+    struct bw_lifecycle_test t;
+    struct lsquic_packet_out *packet_out_1, *packet_out_2;
+
+    init_test(&t, 3, 100000, 0);
+
+    packet_out_1 = new_packet(&t, 1, 1000);
+    packet_out_2 = new_packet(&t, 2, 1200);
+    assert(0 == lsquic_send_ctl_sent_packet(&t.send_ctl, packet_out_1));
+    assert(0 == lsquic_send_ctl_sent_packet(&t.send_ctl, packet_out_2));
+    assert(NULL != packet_out_1->po_bwp_state);
+    assert(NULL != packet_out_2->po_bwp_state);
+
+    ack_one(&t, 1, 2000, 2000, 1);
+
+    assert(!(t.send_ctl.sc_flags & SC_BW_SAMPLER_INIT));
+    assert(NULL == packet_out_2->po_bwp_state);
+
+    cleanup_test(&t);
+}
+
+
+static void
+test_reinit_after_drop_via_get_bw (void)
+{
+    /* After a drop, get_bw() should reinitialize sampler cleanly. */
+    struct bw_lifecycle_test t;
+    struct lsquic_packet_out *packet_out;
+
+    init_test(&t, 3, 100000, 0);
+
+    packet_out = new_packet(&t, 1, 1000);
+    assert(0 == lsquic_send_ctl_sent_packet(&t.send_ctl, packet_out));
+    ack_one(&t, 1, 2000, 2000, 1);
+    assert(!(t.send_ctl.sc_flags & SC_BW_SAMPLER_INIT));
+
+    (void) lsquic_send_ctl_get_bw(&t.send_ctl);
+    assert(t.send_ctl.sc_flags & SC_BW_SAMPLER_INIT);
+
+    cleanup_test(&t);
+}
+
+
+static void
+test_engine_setting_enables_sampler (void)
+{
+    /* Engine default should pre-enable sampler on Cubic connections. */
+    struct bw_lifecycle_test t;
+    struct lsquic_packet_out *packet_out;
+
+    init_test(&t, 1, 100000, 1);
+
+    assert(t.send_ctl.sc_ci == &lsquic_cong_cubic_if);
+    assert(t.send_ctl.sc_flags & SC_KEEP_BW_SAMPLER);
+    assert(t.send_ctl.sc_flags & SC_BW_SAMPLER_INIT);
+
+    packet_out = new_packet(&t, 1, 1000);
+    assert(0 == lsquic_send_ctl_sent_packet(&t.send_ctl, packet_out));
+    assert(NULL != packet_out->po_bwp_state);
+
+    cleanup_test(&t);
+}
+
+
+static void
+test_engine_setting_keeps_sampler_across_adaptive_to_cubic (void)
+{
+    /* Engine default "keep" should survive Adaptive->Cubic transition. */
+    struct bw_lifecycle_test t;
+    struct lsquic_packet_out *packet_out;
+
+    init_test(&t, 3, 100000, 1);
+
+    assert(t.send_ctl.sc_ci == &lsquic_cong_adaptive_if);
+    assert(t.send_ctl.sc_flags & SC_KEEP_BW_SAMPLER);
+    assert(t.send_ctl.sc_flags & SC_BW_SAMPLER_INIT);
+
+    packet_out = new_packet(&t, 1, 1000);
+    assert(0 == lsquic_send_ctl_sent_packet(&t.send_ctl, packet_out));
+    assert(NULL != packet_out->po_bwp_state);
+
+    ack_one(&t, 1, 2000, 2000, 1);
+
+    assert(t.send_ctl.sc_ci == &lsquic_cong_cubic_if);
+    assert(t.send_ctl.sc_flags & SC_KEEP_BW_SAMPLER);
+    assert(t.send_ctl.sc_flags & SC_BW_SAMPLER_INIT);
+
+    packet_out = new_packet(&t, 2, 3000);
+    assert(0 == lsquic_send_ctl_sent_packet(&t.send_ctl, packet_out));
+    assert(NULL != packet_out->po_bwp_state);
+
+    cleanup_test(&t);
+}
+
+
+int
+main (void)
+{
+    lsquic_log_to_fstream(stderr, LLTS_NONE);
+    test_cubic_lazy_enable();
+    test_adaptive_switch_without_info_drops_sampler();
+    test_adaptive_switch_with_info_keeps_sampler();
+    test_drop_clears_inflight_packet_states();
+    test_reinit_after_drop_via_get_bw();
+    test_engine_setting_enables_sampler();
+    test_engine_setting_keeps_sampler_across_adaptive_to_cubic();
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
- [API] Allow to optimize BW sampler use.
- [FIX] Crash in the new bandwidth estimate code.
- [IMPROVEMENT] Transport param checks warnings (gcc 14).