### PR TITLE
fix: inconsistent capitalization fo ws2tcpip.h

### DIFF
--- a/src/liblsquic/lsquic_qlog.c
+++ b/src/liblsquic/lsquic_qlog.c
@@ -6,7 +6,7 @@
 #include <string.h>
 #include <sys/queue.h>
 #ifdef WIN32
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 #else
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/src/liblsquic/lsquic_tokgen.c
+++ b/src/liblsquic/lsquic_tokgen.c
@@ -12,7 +12,7 @@
 #include <sys/socket.h>
 #else
 #include "vc_compat.h"
-#include <Ws2tcpip.h>
+#include <ws2tcpip.h>
 #endif
 
 #include <openssl/aead.h>

--- a/src/liblsquic/lsquic_trans_params.c
+++ b/src/liblsquic/lsquic_trans_params.c
@@ -16,7 +16,7 @@
 #include <sys/socket.h>
 #else
 #include "vc_compat.h"
-#include "Ws2tcpip.h"
+#include "ws2tcpip.h"
 #endif
 
 #include "lsquic.h"


### PR DESCRIPTION
This makes cross compilation from linux to windows hard as linux is case sensitive