### PR TITLE
Disable delayed ACKs by default and remove stale support claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ The following QUIC protocol extensions are implemented:
 - [RFC 9218](https://www.rfc-editor.org/rfc/rfc9218) Extensible Prioritization Scheme for HTTP
 - [RFC 9221](https://www.rfc-editor.org/rfc/rfc9221) An Unreliable Datagram Extension to QUIC
 - [RFC 9287](https://www.rfc-editor.org/rfc/rfc9287) Greasing the QUIC Bit
-- [ACK Frequency](https://datatracker.ietf.org/doc/draft-ietf-quic-ack-frequency/)
 - [WebTransport](https://datatracker.ietf.org/doc/draft-ietf-webtrans-http3/)
   
 Documentation

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -1112,7 +1112,7 @@ out of date.  Please check your :file:`lsquic.h` for actual values.*
 
 .. macro:: LSQUIC_DF_TIMESTAMPS
 
-    The legacy experimental timestamp extension is on by default.
+    The legacy experimental timestamp extension is off by default.
 
 .. macro:: LSQUIC_DF_DATAGRAMS
 

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -766,7 +766,8 @@ settings structure:
 
     .. member:: int             es_timestamps
 
-       Enable timestamps extension.  Allowed values are 0 and 1.
+       Enable the legacy experimental timestamp extension.  Allowed values are
+       0 and 1.
 
        Default value is @ref LSQUIC_DF_TIMESTAMPS
 
@@ -1111,7 +1112,7 @@ out of date.  Please check your :file:`lsquic.h` for actual values.*
 
 .. macro:: LSQUIC_DF_TIMESTAMPS
 
-    Timestamps are on by default.
+    The legacy experimental timestamp extension is on by default.
 
 .. macro:: LSQUIC_DF_DATAGRAMS
 

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -764,12 +764,6 @@ settings structure:
 
        Default value is :macro:`LSQUIC_DF_SPIN`
 
-    .. member:: int             es_delayed_acks
-
-       Enable delayed ACKs extension.  Allowed values are 0 and 1.
-
-       Default value is :macro:`LSQUIC_DF_DELAYED_ACKS`
-
     .. member:: int             es_timestamps
 
        Enable timestamps extension.  Allowed values are 0 and 1.
@@ -1081,10 +1075,6 @@ out of date.  Please check your :file:`lsquic.h` for actual values.*
 .. macro:: LSQUIC_DF_CC_RTT_THRESH
 
     Default value of the CC RTT threshold is 1500 microseconds
-
-.. macro:: LSQUIC_DF_DELAYED_ACKS
-
-    The Delayed ACKs extension is on by default.
 
 .. macro:: LSQUIC_DF_MAX_UDP_PAYLOAD_SIZE_RX
 

--- a/docs/delayed-acks-status.md
+++ b/docs/delayed-acks-status.md
@@ -1,0 +1,131 @@
+# Delayed ACKs / ACK_FREQUENCY State Report
+
+## Executive Summary
+
+LSQUIC still contains a substantial delayed-ACK implementation, but it matches the older 2020 delayed-ack draft rather than the current `draft-ietf-quic-ack-frequency` design.
+
+As of February 28, 2026, the current published `ack-frequency` draft is `draft-ietf-quic-ack-frequency-14` (January 19, 2024). Relative to that draft, the implementation in this tree is not wire-compatible in key areas:
+
+- It uses obsolete `min_ack_delay` transport parameter IDs.
+- It encodes `ACK_FREQUENCY` using the older layout with a trailing boolean `Ignore Order`.
+- It does not implement `IMMEDIATE_ACK`.
+- It uses old-draft semantics where the current draft uses a numeric reordering threshold.
+
+The feature is best described as legacy experimental support for the older delayed-ack draft, not current ACK Frequency support.
+
+## What Exists In Tree
+
+The implementation is functional and not just parser scaffolding:
+
+- The feature was introduced in 2020 as experimental delayed-ACK support.
+- It advertises legacy delayed-ack transport parameters.
+- It parses incoming `ACK_FREQUENCY` frames and can generate outgoing `ACK_FREQUENCY` frames.
+- It includes a packet-tolerance controller that adjusts the peer's ACK cadence based on observed ACKs per RTT.
+
+Relevant source files:
+
+- `include/lsquic.h`
+- `src/liblsquic/lsquic_engine.c`
+- `src/liblsquic/lsquic_enc_sess_ietf.c`
+- `src/liblsquic/lsquic_full_conn_ietf.c`
+- `src/liblsquic/lsquic_parse_ietf_v1.c`
+- `src/liblsquic/lsquic_trans_params.c`
+- `src/liblsquic/lsquic_trans_params.h`
+
+## Where It Matches The Older Delayed-ACK Draft
+
+### Old frame layout
+
+The current parser and generator still use:
+
+- frame type `0xAF`
+- `Sequence Number`
+- `Packet Tolerance`
+- `Update Max Ack Delay`
+- `Ignore Order` as a trailing one-byte boolean
+
+That matches the older delayed-ack draft layout, not the current `ack-frequency` frame format.
+
+### Obsolete transport parameter IDs
+
+The implementation still recognizes and emits legacy delayed-ack transport parameter IDs:
+
+- `0xDE1A`
+- `0xFF02DE1A`
+
+It does not emit the current `min_ack_delay` transport parameter ID used by the modern draft.
+
+### Old terminology
+
+The implementation and comments still use older delayed-ack terminology:
+
+- `Packet Tolerance`
+- `Ignore Order`
+- `Delayed ACKs`
+
+The current draft instead uses:
+
+- `Ack-Eliciting Threshold`
+- `Reordering Threshold`
+- `ACK Frequency`
+
+## Mismatch Against The Current Draft
+
+### 1. Negotiation is outdated
+
+The current draft uses a different `min_ack_delay` transport parameter ID. This implementation still uses the older IDs, so negotiation with a modern peer is likely to fail unless that peer still carries compatibility code for the older delayed-ack drafts.
+
+### 2. `ACK_FREQUENCY` payload is outdated
+
+The current draft uses four varints:
+
+- `Sequence Number`
+- `Ack-Eliciting Threshold`
+- `Requested Max Ack Delay`
+- `Reordering Threshold`
+
+This implementation still expects the last field to be a single-byte boolean. A modern peer can therefore fail to interoperate even if frame type `0xAF` is recognized.
+
+### 3. `IMMEDIATE_ACK` is missing
+
+The current draft also defines `IMMEDIATE_ACK` (`0x1f`). There is no implementation support for that frame in the current tree.
+
+### 4. Sender-side max-ack-delay requests are effectively not used
+
+The sender negotiates `min_ack_delay`, but the code path that generates `ACK_FREQUENCY` frames reuses the peer's existing `max_ack_delay` value instead of actively requesting a new max ACK delay. In practice, the implementation mainly adjusts only the packet-count side of delayed ACKs.
+
+### 5. Automatic sending is coupled to BBR
+
+The packet-tolerance control loop is only initially armed when the send controller is using direct BBR. That means the automatic outgoing `ACK_FREQUENCY` path is not universally active across congestion-control choices.
+
+## Testing State
+
+There does not appear to be dedicated unit-test coverage under `tests/` for:
+
+- `ACK_FREQUENCY` frame encode/decode
+- delayed-ack transport parameter encode/decode
+- current-draft ACK Frequency behavior
+
+That leaves the legacy implementation with weak regression coverage and increases the cost of a spec refresh.
+
+## Recommendation
+
+### Short term
+
+- Keep the legacy implementation in tree if it is still useful for experiments.
+- Do not enable it by default.
+- Do not advertise it as supported in user-facing docs.
+
+### Follow-up work
+
+To resuscitate the feature for current-spec interoperability:
+
+- replace legacy `min_ack_delay` transport parameter IDs with the current one
+- update `ACK_FREQUENCY` parsing and generation to the current four-varint format
+- add `IMMEDIATE_ACK`
+- rename or rework the `Ignore Order` behavior into a current-draft reordering-threshold model
+- add explicit transport-parameter and frame-level tests
+
+## Overall Verdict
+
+The code is still present and substantial, but it is legacy delayed-ack code, not current ACK Frequency support. It should be treated as obsolete experimental functionality until it is refreshed against the modern draft.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,7 +39,6 @@ LSQUIC supports nearly all QUIC and HTTP/3 features, including
  - :ref:`extensible-http-priorities`
  - :ref:`apiref-datagrams`
  - Loss bits extension (allowing network observer to locate source of packet loss)
- - Timestamps extension (allowing for one-way delay calculation, improving performance of some congestion controllers)
  - QUIC grease bit to reduce ossification opportunities
 
 Architecture

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,6 @@ LSQUIC supports nearly all QUIC and HTTP/3 features, including
  - :ref:`apiref-datagrams`
  - Loss bits extension (allowing network observer to locate source of packet loss)
  - Timestamps extension (allowing for one-way delay calculation, improving performance of some congestion controllers)
- - Delayed ACKs (this reduces number of ACK frames sent and processed, improving throughput)
  - QUIC grease bit to reduce ossification opportunities
 
 Architecture

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1248,7 +1248,8 @@ it possible to store a list of frame types as a bitmask.  Examples include
 Some frame types, such as ACK and STREAM, are common to both Google and IETF
 QUIC.  Others, such as STOP_WAITING and RETIRE_CONNECTION_ID, are only used
 in one of the protocols.  The third type is frames that are used by IETF
-QUIC extensions, such as TIMESTAMP and ACK_FREQUENCY.
+QUIC extensions and legacy extension code paths, such as TIMESTAMP and
+ACK_FREQUENCY.
 
 Parsing IETF QUIC Frame Types
 -----------------------------
@@ -2141,7 +2142,7 @@ ifc_created
 -----------
 
 Time when the connection was created.  This is used for the Timestamp
-and Delayed ACKs extensions.
+extension and legacy delayed-ACK code paths.
 
 ifc_saved_ack_received
 ----------------------
@@ -2192,8 +2193,8 @@ ifc_max_retx_since_last_ack
 This number is the maximum number of ack-eliciting packets to receive
 before an ACK must be sent.
 
-The default value is 2.  When the Delayed ACKs extension is used, this
-value gets modified by peer's ACK_FREQUENCY frames.
+The default value is 2.  In the legacy delayed-ACK code path, this
+value can be modified by peer's ACK_FREQUENCY frames.
 
 ifc_max_ack_delay
 -----------------
@@ -2201,8 +2202,8 @@ ifc_max_ack_delay
 Maximum amount of allowed after before an ACK is sent if the threshold
 defined by ifc_max_retx_since_last_ack_ has not yet been reached.
 
-The default value is 25 ms.  When the Delayed ACKs extension is used, this
-value gets modified by peer's ACK_FREQUENCY frames.
+The default value is 25 ms.  In the legacy delayed-ACK code path, this
+value can be modified by peer's ACK_FREQUENCY frames.
 
 ifc_ecn_counts_in
 -----------------
@@ -2448,7 +2449,7 @@ ifc_pts
 
 PTS stands for "Packet Tolerance Stats".  Information collected here
 is used to calculate updates to the packet tolerance advertised to the
-peer via ACK_FREQUENCY frames.  Part of the Delayed ACKs extension.
+peer via ACK_FREQUENCY frames in the legacy delayed-ACK code path.
 
 ifc_stats
 ---------
@@ -2647,7 +2648,8 @@ Creating Streams on the Server
 Calculating Packet Tolerance
 ============================
 
-When the Delayed ACKs extension is used, we advertise our ``Packet Tolerance``
+When the legacy delayed-ACK code path is active, we advertise our
+``Packet Tolerance``
 to peer.  This is the number of packets the peer can receive before having to
 send an acknowledgement.  By default -- without the extension -- the packet
 tolerance is 2.

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1247,9 +1247,8 @@ it possible to store a list of frame types as a bitmask.  Examples include
 
 Some frame types, such as ACK and STREAM, are common to both Google and IETF
 QUIC.  Others, such as STOP_WAITING and RETIRE_CONNECTION_ID, are only used
-in one of the protocols.  The third type is frames that are used by IETF
-QUIC extensions and legacy extension code paths, such as TIMESTAMP and
-ACK_FREQUENCY.
+in one of the protocols.  The third type is frames that are used by legacy
+extension code paths, such as TIMESTAMP and ACK_FREQUENCY.
 
 Parsing IETF QUIC Frame Types
 -----------------------------

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -390,12 +390,12 @@ typedef struct ssl_ctx_st * (*lsquic_lookup_cert_f)(
 /** Turn spin bit on by default */
 #define LSQUIC_DF_SPIN 1
 
-/** Turn on delayed ACKs extension by default */
-#define LSQUIC_DF_DELAYED_ACKS 1
+/** Keep the legacy delayed-ACKs experiment disabled by default */
+#define LSQUIC_DF_DELAYED_ACKS 0
 
 /**
  * Defaults for the Packet Tolerance PID Controller (PTPC) used by the
- * Delayed ACKs extension:
+ * legacy packet-tolerance logic:
  */
 #define LSQUIC_DF_PTPC_PERIODICITY 3
 #define LSQUIC_DF_PTPC_MAX_PACKTOL 150
@@ -958,7 +958,7 @@ struct lsquic_engine_settings {
     int             es_spin;
 
     /**
-     * Enable delayed ACKs extension.  Allowed values are 0 and 1.
+     * Toggle the legacy delayed-ACKs experiment.  Allowed values are 0 and 1.
      *
      * Default value is @ref LSQUIC_DF_DELAYED_ACKS
      */
@@ -1075,7 +1075,7 @@ struct lsquic_engine_settings {
 
     /**
      * Settings for the Packet Tolerance PID Controller (PTPC) used for
-     * the Delayed ACKs logic.  Periodicity is how often the number of
+     * the legacy packet-tolerance logic.  Periodicity is how often the number of
      * incoming ACKs is sampled.  Periodicity's units is the number of
      * RTTs. Target is the average number of incoming ACKs per RTT we
      * want to achieve.  Error threshold defines the range of error values

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -406,8 +406,8 @@ typedef struct ssl_ctx_st * (*lsquic_lookup_cert_f)(
 #define LSQUIC_DF_PTPC_ERR_THRESH 0.05
 #define LSQUIC_DF_PTPC_ERR_DIVISOR 0.05
 
-/** Keep the legacy experimental timestamp extension enabled by default */
-#define LSQUIC_DF_TIMESTAMPS 1
+/** Keep the legacy experimental timestamp extension disabled by default */
+#define LSQUIC_DF_TIMESTAMPS 0
 
 /** default anti-amplification factor is 3 */
 #define LSQUIC_DF_AMP_FACTOR 3

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -406,7 +406,7 @@ typedef struct ssl_ctx_st * (*lsquic_lookup_cert_f)(
 #define LSQUIC_DF_PTPC_ERR_THRESH 0.05
 #define LSQUIC_DF_PTPC_ERR_DIVISOR 0.05
 
-/** Turn on timestamp extension by default */
+/** Keep the legacy experimental timestamp extension enabled by default */
 #define LSQUIC_DF_TIMESTAMPS 1
 
 /** default anti-amplification factor is 3 */
@@ -965,7 +965,8 @@ struct lsquic_engine_settings {
     int             es_delayed_acks;
 
     /**
-     * Enable timestamps extension.  Allowed values are 0 and 1.
+     * Enable the legacy experimental timestamp extension.  Allowed values are
+     * 0 and 1.
      *
      * Default value is @ref LSQUIC_DF_TIMESTAMPS
      */


### PR DESCRIPTION
## Summary
- disable the legacy delayed-ACKs path by default
- remove user-facing README and documentation claims that ACK Frequency / delayed ACKs are currently supported
- add a sanitized status report under `docs/` describing the legacy state of the implementation

## Follow-up
- tracks issue #623 (`Resuscitate delayed ACKs support`)

## Testing
- `git diff --check`
- verified the removed support-language no longer appears in README and public docs