### PR TITLE
Guard nonstring attributes with __GNUC__

### DIFF
--- a/src/liblsquic/lsquic_tokgen.c
+++ b/src/liblsquic/lsquic_tokgen.c
@@ -70,7 +70,9 @@ static const uint64_t salts[N_TOKEN_TYPES] =
     [TOKEN_RESUME] = 0x0b3664549086b8ca,
 };
 
+#if __GNUC__
 __attribute__((nonstring))
+#endif
 static const uint8_t srst_salt[8] = "\x28\x6e\x81\x02\x40\x5b\x2c\x2b";
 
 struct crypter

--- a/src/liblsquic/lsquic_util.c
+++ b/src/liblsquic/lsquic_util.c
@@ -189,7 +189,9 @@ lsquic_hex_encode (const void *src, size_t src_sz, void *dst, size_t dst_sz)
 void
 lsquic_hexstr (const unsigned char *buf, size_t bufsz, char *out, size_t outsz)
 {
+#if __GNUC__
     __attribute__((nonstring))
+#endif
     static const char b2c[16] = "0123456789ABCDEF";
     const unsigned char *const end_input = buf + bufsz;
     char *const end_output = out + outsz;

--- a/tests/test_export_key.c
+++ b/tests/test_export_key.c
@@ -19,7 +19,9 @@ struct export_key_test
     size_t              ekt_ikm_sz,
                         ekt_salt_sz,
                         ekt_context_sz;
+#if __GNUC__
     __attribute__((nonstring))
+#endif
     unsigned char       ekt_ikm[0x20],
                         ekt_salt[0x60],
                         ekt_context[0x1000];
@@ -28,7 +30,9 @@ struct export_key_test
                         ekt_client_key_sz,
                         ekt_client_iv_sz;
     /* Output: */
+#if __GNUC__
     __attribute__((nonstring))
+#endif
     unsigned char       ekt_server_key[32],
                         ekt_client_key[32],
                         ekt_server_iv[4],

--- a/tests/test_varint.c
+++ b/tests/test_varint.c
@@ -14,7 +14,9 @@
 struct test_read_varint
 {
     /* Input: */
+#if __GNUC__
     __attribute__((nonstring))
+#endif
     unsigned char       input[MAX_INPUT_SZ];
     size_t              in_sz;
     /* Output: */


### PR DESCRIPTION
Wrap the recently added \ annotations in \ guards so MSVC does not try to parse them.

This follows the existing style in the tree for compiler-specific attributes and avoids introducing a broader compatibility macro.