### PR TITLE
Fix #616: return TP-specific close code when peer transport params fail

### DIFF
--- a/src/liblsquic/lsquic_enc_sess.h
+++ b/src/liblsquic/lsquic_enc_sess.h
@@ -3,6 +3,7 @@
 #define LSQUIC_ENC_SESS_H 1
 
 #include "lsquic_shared_support.h"
+#include "lsquic_ietf.h"
 
 struct lsquic_alarmset;
 struct lsquic_engine_public;
@@ -279,6 +280,9 @@ struct enc_session_funcs_iquic
 
     struct transport_params *
     (*esfi_get_peer_transport_params) (enc_session_t *);
+
+    enum trans_error_code
+    (*esfi_get_peer_transport_error) (enc_session_t *);
 
     int
     (*esfi_reset_dcid) (enc_session_t *, const struct lsquic_cid *,

--- a/src/liblsquic/lsquic_enc_sess_ietf.c
+++ b/src/liblsquic/lsquic_enc_sess_ietf.c
@@ -296,6 +296,8 @@ struct enc_sess_iquic
     struct lsquic_packet_out *
                          esi_hp_batch_packets[HP_BATCH_SIZE];
     unsigned char        esi_hp_batch_samples[HP_BATCH_SIZE][SAMPLE_SZ];
+    enum trans_error_code
+                         esi_tp_error;
     unsigned char        esi_grease;
     signed char          esi_have_forw;
 };
@@ -864,6 +866,7 @@ iquic_esfi_create_client (const char *hostname,
     enc_sess->esi_odcid = *dcid;
     enc_sess->esi_flags |= ESI_ODCID;
     enc_sess->esi_grease = 0xFF;
+    enc_sess->esi_tp_error = TEC_NO_ERROR;
 
     LSQ_DEBUGC("created client, DCID: %"CID_FMT, CID_BITS(dcid));
     {
@@ -1058,6 +1061,7 @@ iquic_esfi_create_server (struct lsquic_engine_public *enpub,
     enc_sess->esi_enpub = enpub;
     enc_sess->esi_conn = lconn;
     enc_sess->esi_grease = 0xFF;
+    enc_sess->esi_tp_error = TEC_NO_ERROR;
 
     if (odcid)
     {
@@ -1734,6 +1738,8 @@ get_peer_transport_params (struct enc_sess_iquic *enc_sess)
     const enum lsquic_version version = enc_sess->esi_conn->cn_version;
     int have_0rtt_tp;
 
+    enc_sess->esi_tp_error = TEC_TRANSPORT_PARAMETER_ERROR;
+
     SSL_get_peer_quic_transport_params(enc_sess->esi_ssl, &params_buf, &bufsz);
     if (!params_buf || !bufsz)
     {
@@ -1784,7 +1790,10 @@ get_peer_transport_params (struct enc_sess_iquic *enc_sess)
 
     if (have_0rtt_tp && 0 != check_server_tps_for_violations(enc_sess,
                                                 &params_0rtt, trans_params))
+    {
+        enc_sess->esi_tp_error = TEC_PROTOCOL_VIOLATION;
         return -1;
+    }
 
     const lsquic_cid_t *const cids[LAST_TPI + 1] = {
         [TP_CID_IDX(TPI_ORIGINAL_DEST_CID)]  = enc_sess->esi_flags & ESI_ODCID ? &enc_sess->esi_odcid : NULL,
@@ -1824,6 +1833,7 @@ get_peer_transport_params (struct enc_sess_iquic *enc_sess)
         {
             LSQ_WARN("do not have CID %s for checking",
                                                     lsquic_tpi2str[tpi]);
+            enc_sess->esi_tp_error = TEC_INTERNAL_ERROR;
             return -1;
         }
         if (LSQUIC_CIDS_EQ(cids[TP_CID_IDX(tpi)],
@@ -1910,6 +1920,7 @@ get_peer_transport_params (struct enc_sess_iquic *enc_sess)
             LSQ_INFO("peer transport parameters: %s=%"PRIu64" does not pass "
                 "sanity check", lsquic_tpi2str[stream_data],
                 trans_params->tp_numerics[stream_data]);
+            enc_sess->esi_tp_error = TEC_PROTOCOL_VIOLATION;
             return -1;
         }
         if (!((trans_params->tp_set & (1 << TPI_INIT_MAX_DATA))
@@ -1918,10 +1929,12 @@ get_peer_transport_params (struct enc_sess_iquic *enc_sess)
             LSQ_INFO("peer transport parameters: %s=%"PRIu64" does not pass "
                 "sanity check", lsquic_tpi2str[TPI_INIT_MAX_DATA],
                 trans_params->tp_numerics[TPI_INIT_MAX_DATA]);
+            enc_sess->esi_tp_error = TEC_PROTOCOL_VIOLATION;
             return -1;
         }
     }
 
+    enc_sess->esi_tp_error = TEC_NO_ERROR;
     return 0;
 }
 
@@ -1932,11 +1945,17 @@ maybe_get_peer_transport_params (struct enc_sess_iquic *enc_sess)
     int s;
 
     if (enc_sess->esi_flags & ESI_HAVE_PEER_TP)
+    {
+        enc_sess->esi_tp_error = TEC_NO_ERROR;
         return 0;
+    }
 
     s = get_peer_transport_params(enc_sess);
     if (s == 0)
+    {
         enc_sess->esi_flags |= ESI_HAVE_PEER_TP;
+        enc_sess->esi_tp_error = TEC_NO_ERROR;
+    }
 
     return s;
 }
@@ -2049,11 +2068,22 @@ iquic_esfi_get_peer_transport_params (enc_session_t *enc_session_p)
     struct enc_sess_iquic *const enc_sess = enc_session_p;
 
     if (enc_sess->esi_flags & ESI_HAVE_0RTT_TP)
+    {
+        enc_sess->esi_tp_error = TEC_NO_ERROR;
         return &enc_sess->esi_peer_tp;
+    }
     else if (0 == maybe_get_peer_transport_params(enc_sess))
         return &enc_sess->esi_peer_tp;
     else
         return NULL;
+}
+
+
+static enum trans_error_code
+iquic_esfi_get_peer_transport_error (enc_session_t *enc_session_p)
+{
+    struct enc_sess_iquic *const enc_sess = enc_session_p;
+    return enc_sess->esi_tp_error;
 }
 
 
@@ -2841,6 +2871,8 @@ const struct enc_session_funcs_iquic lsquic_enc_session_iquic_ietf_v1 =
     .esfi_destroy        = iquic_esfi_destroy,
     .esfi_get_peer_transport_params
                          = iquic_esfi_get_peer_transport_params,
+    .esfi_get_peer_transport_error
+                         = iquic_esfi_get_peer_transport_error,
     .esfi_reset_dcid     = iquic_esfi_reset_dcid,
     .esfi_init_server    = iquic_esfi_init_server,
     .esfi_set_iscid      = iquic_esfi_set_iscid,

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -3872,6 +3872,16 @@ handshake_ok (struct lsquic_conn *lconn)
                                                         lconn->cn_enc_session);
     if (!params)
     {
+        if (0 == conn->ifc_error.u.err)
+        {
+            enum trans_error_code code = TEC_TRANSPORT_PARAMETER_ERROR;
+            if (lconn->cn_esf.i->esfi_get_peer_transport_error)
+                code = lconn->cn_esf.i->esfi_get_peer_transport_error(
+                                                    lconn->cn_enc_session);
+            if (0 == code)
+                code = TEC_TRANSPORT_PARAMETER_ERROR;
+            conn->ifc_error = CONN_ERR(0, code);
+        }
         ABORT_WARN("could not get transport parameters");
         return -1;
     }
@@ -10098,4 +10108,3 @@ static const struct lsquic_stream_if unicla_if =
 static const struct lsquic_stream_if *unicla_if_ptr = &unicla_if;
 
 typedef char dcid_elem_fits_in_128_bytes[sizeof(struct dcid_elem) <= 128 ? 1 : - 1];
-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ SET(TESTS
     goaway_gquic_be
     hkdf
     hpi
+    issue_616
     lsquic_hash
     mini_conn_delay
     packet_out

--- a/tests/test_issue_616.c
+++ b/tests/test_issue_616.c
@@ -1,0 +1,205 @@
+/* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
+#include <inttypes.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/queue.h>
+
+#include "lsquic.h"
+#include "lsquic_int_types.h"
+#include "lsquic_sizes.h"
+#include "lsquic_hash.h"
+#include "lsquic_mm.h"
+#include "lsquic_conn.h"
+#include "lsquic_crand.h"
+#include "lsquic_engine_public.h"
+#include "lsquic_full_conn.h"
+#include "lsquic_ietf.h"
+#include "lsquic_packet_common.h"
+#include "lsquic_packet_out.h"
+#include "lsquic_parse.h"
+#include "lsquic_types.h"
+#include "lsquic_util.h"
+
+
+static lsquic_conn_ctx_t *
+on_new_conn (void *stream_if_ctx, lsquic_conn_t *conn)
+{
+    (void) stream_if_ctx;
+    (void) conn;
+    return NULL;
+}
+
+
+static void
+on_conn_closed (lsquic_conn_t *conn)
+{
+    (void) conn;
+}
+
+
+static const struct lsquic_stream_if stream_if = {
+    .on_new_conn    = on_new_conn,
+    .on_conn_closed = on_conn_closed,
+};
+
+static void *
+pmi_allocate (void *ctx, void *peer_ctx, lsquic_conn_ctx_t *conn_ctx,
+                                            unsigned short sz, char is_ipv6)
+{
+    (void) ctx;
+    (void) peer_ctx;
+    (void) conn_ctx;
+    (void) is_ipv6;
+    return malloc(sz);
+}
+
+
+static void
+pmi_release (void *ctx, void *peer_ctx, void *buf, char is_ipv6)
+{
+    (void) ctx;
+    (void) peer_ctx;
+    (void) is_ipv6;
+    free(buf);
+}
+
+
+static void
+pmi_return (void *ctx, void *peer_ctx, void *buf, char is_ipv6)
+{
+    (void) ctx;
+    (void) peer_ctx;
+    (void) is_ipv6;
+    free(buf);
+}
+
+
+static const struct lsquic_packout_mem_if packout_mem_if = {
+    .pmi_allocate = pmi_allocate,
+    .pmi_release  = pmi_release,
+    .pmi_return   = pmi_return,
+};
+
+
+static void
+gen_scid (void *ctx, struct lsquic_conn *conn, uint8_t *scid, unsigned len)
+{
+    (void) ctx;
+    (void) conn;
+    memset(scid, 0xAB, len);
+}
+
+
+static int
+extract_close_code (uint64_t *close_code)
+{
+    struct lsquic_engine_public enpub;
+    struct crand crand;
+    static unsigned char alpn[] = "\x02h3";
+    struct lsquic_conn *conn;
+    struct lsquic_packet_out *packet_out;
+    int app_error;
+    uint16_t reason_len;
+    uint8_t reason_off;
+    int parsed, i;
+    int rv = -1;
+
+    memset(&enpub, 0, sizeof(enpub));
+    memset(&crand, 0, sizeof(crand));
+
+    lsquic_mm_init(&enpub.enp_mm);
+    lsquic_engine_init_settings(&enpub.enp_settings, 0);
+    enpub.enp_crand = &crand;
+    enpub.enp_stream_if = &stream_if;
+    enpub.enp_generate_scid = gen_scid;
+    enpub.enp_pmi = &packout_mem_if;
+    enpub.enp_flags = ENPUB_PROC;  /* Disable engine queue operations. */
+    enpub.enp_settings.es_scid_len = 8;
+    enpub.enp_settings.es_silent_close = 0;
+    enpub.enp_alpn = alpn;
+
+    /* Use server flag to bypass client version-negotiation early return in
+     * immediate_close(), so we can inspect the generated close code directly.
+     */
+    conn = lsquic_ietf_full_conn_client_new(&enpub, 1u << LSQVER_I001,
+        LSENG_SERVER,
+        "localhost", 0, 1, NULL, 0, NULL, 0, NULL);
+    if (!conn)
+    {
+        fprintf(stderr, "cannot create full IETF conn\n");
+        goto cleanup;
+    }
+    /* Trigger handshake_ok() while peer TPs are unavailable.  This hits the
+     * same close-code mapping used for TP decode failures.
+     */
+    conn->cn_if->ci_hsk_done(conn, LSQ_HSK_OK);
+
+    packet_out = NULL;
+    for (i = 0; i < 4 && !packet_out; ++i)
+    {
+        (void) conn->cn_if->ci_tick(conn, lsquic_time_now());
+        packet_out = conn->cn_if->ci_next_packet_to_send(conn, NULL);
+    }
+
+    if (!packet_out)
+    {
+        fprintf(stderr, "no packet generated after handshake failure\n");
+        goto destroy;
+    }
+
+    if (!(packet_out->po_frame_types & (1 << QUIC_FRAME_CONNECTION_CLOSE)))
+    {
+        fprintf(stderr, "expected CONNECTION_CLOSE frame, frame bits: 0x%X\n",
+            packet_out->po_frame_types);
+        goto destroy;
+    }
+
+    parsed = conn->cn_pf->pf_parse_connect_close_frame(packet_out->po_data,
+        packet_out->po_data_sz, &app_error, close_code, &reason_len,
+        &reason_off);
+    if (parsed <= 0)
+    {
+        fprintf(stderr, "cannot parse generated CONNECTION_CLOSE frame\n");
+        goto destroy;
+    }
+
+    rv = 0;
+
+destroy:
+    conn->cn_if->ci_destroy(conn);
+cleanup:
+    lsquic_mm_cleanup(&enpub.enp_mm);
+    return rv;
+}
+
+
+int
+main (void)
+{
+    uint64_t close_code;
+
+    if (0 != lsquic_global_init(LSQUIC_GLOBAL_CLIENT))
+    {
+        fprintf(stderr, "lsquic_global_init failed\n");
+        return 1;
+    }
+    if (0 != extract_close_code(&close_code))
+    {
+        lsquic_global_cleanup();
+        return 1;
+    }
+
+    printf("close_code=%"PRIu64"\n", close_code);
+    if (close_code != TEC_TRANSPORT_PARAMETER_ERROR)
+    {
+        fprintf(stderr, "expected close code %"PRIu64", got %"PRIu64"\n",
+            (uint64_t) TEC_TRANSPORT_PARAMETER_ERROR, close_code);
+        lsquic_global_cleanup();
+        return 2;
+    }
+
+    lsquic_global_cleanup();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a focused regression test (tests/test_issue_616.c) that reproduces issue #616 by forcing handshake completion before peer transport parameters are available
- in full conn handshake path, when esfi_get_peer_transport_params() fails and no prior error is set, map close code from enc-session TP classification instead of defaulting to TEC_INTERNAL_ERROR
- add esfi_get_peer_transport_error() to the IETF enc-session interface and implement TP-failure classification (TEC_TRANSPORT_PARAMETER_ERROR, TEC_PROTOCOL_VIOLATION, TEC_INTERNAL_ERROR)
- keep esi_tp_error enum-typed and reset to TEC_NO_ERROR on successful TP retrieval/cached TP paths

## Repro / Verification
- cmake --build build --target test_issue_616 -j4
- ./build/tests/test_issue_616 -> close_code=8
- cd build && ctest -R issue_616 --output-on-failure

## Notes
- local logs retained in tests/logs/ (not added to commit).