### PR TITLE
fix: prevent ACK frame generation overflow and add regression test

### DIFF
--- a/src/liblsquic/lsquic_parse_ietf_v1.c
+++ b/src/liblsquic/lsquic_parse_ietf_v1.c
@@ -1060,7 +1060,10 @@ ietf_v1_gen_ack_frame (unsigned char *outbuf, size_t outbuf_sz,
         a = vint_val2bits(gap - 1);
         b = vint_val2bits(rsize);
         if (ecn_needs + (1 << a) + (1 << b)
-                + (addl_ack_blocks == VINT_MAX_ONE_BYTE) > (unsigned)AVAIL()) break;
+                + (addl_ack_blocks == VINT_MAX_ONE_BYTE) > (unsigned)AVAIL())
+        {
+            break;
+        }
         if (addl_ack_blocks == VINT_MAX_ONE_BYTE)
         {
             memmove(block_count_p + 2, block_count_p + 1,
@@ -1089,7 +1092,8 @@ ietf_v1_gen_ack_frame (unsigned char *outbuf, size_t outbuf_sz,
         else
             for (ecn = 1; ecn <= 3; ++ecn)
             {
-                vint_write(p, ecn_counts[ecnmap[ecn]], bits[ecnmap[ecn]], 1 << bits[ecnmap[ecn]]);
+                vint_write(p, ecn_counts[ecnmap[ecn]], bits[ecnmap[ecn]],
+                                                    1 << bits[ecnmap[ecn]]);
                 p += 1 << bits[ecnmap[ecn]];
             }
     }

--- a/src/liblsquic/lsquic_parse_ietf_v1.c
+++ b/src/liblsquic/lsquic_parse_ietf_v1.c
@@ -1059,8 +1059,8 @@ ietf_v1_gen_ack_frame (unsigned char *outbuf, size_t outbuf_sz,
         rsize = range->high - range->low;
         a = vint_val2bits(gap - 1);
         b = vint_val2bits(rsize);
-        if (ecn_needs + (1 << a) + (1 << b) > (unsigned)AVAIL())
-            break;
+        if (ecn_needs + (1 << a) + (1 << b)
+                + (addl_ack_blocks == VINT_MAX_ONE_BYTE) > (unsigned)AVAIL()) break;
         if (addl_ack_blocks == VINT_MAX_ONE_BYTE)
         {
             memmove(block_count_p + 2, block_count_p + 1,
@@ -1084,12 +1084,14 @@ ietf_v1_gen_ack_frame (unsigned char *outbuf, size_t outbuf_sz,
 
     if (ecn_counts)
     {
-        assert(ecn_needs <= (unsigned)AVAIL());
-        for (ecn = 1; ecn <= 3; ++ecn)
-        {
-            vint_write(p, ecn_counts[ecnmap[ecn]], bits[ecnmap[ecn]], 1 << bits[ecnmap[ecn]]);
-            p += 1 << bits[ecnmap[ecn]];
-        }
+        if (ecn_needs > (unsigned)AVAIL())
+            outbuf[0] = 0x02;
+        else
+            for (ecn = 1; ecn <= 3; ++ecn)
+            {
+                vint_write(p, ecn_counts[ecnmap[ecn]], bits[ecnmap[ecn]], 1 << bits[ecnmap[ecn]]);
+                p += 1 << bits[ecnmap[ecn]];
+            }
     }
 
     *has_missing = addl_ack_blocks > 0;

--- a/tests/test_ack.c
+++ b/tests/test_ack.c
@@ -207,6 +207,39 @@ run_test (const struct test *test)
     compare_ackis(&test->acki, &acki);
 }
 
+
+static void
+test_ack_block_count_expansion_regression (void)
+{
+    const struct parse_funcs *pf;
+    struct ack_info acki;
+    struct rechist rechist;
+    lsquic_packno_t largest_received;
+    unsigned char buf[140];
+    size_t outbuf_sz;
+    unsigned i;
+    int len, has_missing;
+
+    pf = select_pf_by_ver(LSQVER_I001);
+    memset(&acki, 0, sizeof(acki));
+    acki.n_ranges = 65;
+    for (i = 0; i < acki.n_ranges; ++i)
+        acki.ranges[i].high = acki.ranges[i].low = 128 - i * 2;
+
+    memset(buf, 0xA5, sizeof(buf));
+    outbuf_sz = 134;
+    rechist.acki = &acki;
+    len = pf->pf_gen_ack_frame(buf, outbuf_sz, rechist_first, rechist_next,
+        rechist_largest_recv, &rechist, now, &has_missing, &largest_received,
+        NULL);
+    assert(len > 0);
+    assert((size_t) len <= outbuf_sz);
+    assert(buf[outbuf_sz] == 0xA5);
+    assert(largest_received == acki.ranges[0].high);
+    assert(has_missing);
+}
+
+
 int
 main (void)
 {
@@ -214,6 +247,7 @@ main (void)
 
     for (test = tests; test < tests + sizeof(tests) / sizeof(tests[0]); ++test)
         run_test(test);
+    test_ack_block_count_expansion_regression();
 
     return 0;
 }


### PR DESCRIPTION
Summary:
- fix ACK frame generation bounds at the additional block-count varint growth boundary
- avoid ECN tail overrun by downgrading to non-ECN ACK when ECN counts do not fit
- add regression test for the 63->64 additional ACK-block transition using an outbuf boundary canary

Validation:
- make -C tests test_ack
- ./tests/test_ack (fails before fix at new regression assertion; passes with fix)
