### PR TITLE
Fix nonstring attribute compatibility with older GCC versions

### DIFF
--- a/src/liblsquic/lsquic_tokgen.c
+++ b/src/liblsquic/lsquic_tokgen.c
@@ -70,7 +70,7 @@ static const uint64_t salts[N_TOKEN_TYPES] =
     [TOKEN_RESUME] = 0x0b3664549086b8ca,
 };
 
-#if __GNUC__
+#if __GNUC__ >= 8
 __attribute__((nonstring))
 #endif
 static const uint8_t srst_salt[8] = "\x28\x6e\x81\x02\x40\x5b\x2c\x2b";

--- a/src/liblsquic/lsquic_util.c
+++ b/src/liblsquic/lsquic_util.c
@@ -189,7 +189,7 @@ lsquic_hex_encode (const void *src, size_t src_sz, void *dst, size_t dst_sz)
 void
 lsquic_hexstr (const unsigned char *buf, size_t bufsz, char *out, size_t outsz)
 {
-#if __GNUC__
+#if __GNUC__ >= 8
     __attribute__((nonstring))
 #endif
     static const char b2c[16] = "0123456789ABCDEF";

--- a/tests/test_export_key.c
+++ b/tests/test_export_key.c
@@ -19,7 +19,7 @@ struct export_key_test
     size_t              ekt_ikm_sz,
                         ekt_salt_sz,
                         ekt_context_sz;
-#if __GNUC__
+#if __GNUC__ >= 8
     __attribute__((nonstring))
 #endif
     unsigned char       ekt_ikm[0x20],
@@ -30,7 +30,7 @@ struct export_key_test
                         ekt_client_key_sz,
                         ekt_client_iv_sz;
     /* Output: */
-#if __GNUC__
+#if __GNUC__ >= 8
     __attribute__((nonstring))
 #endif
     unsigned char       ekt_server_key[32],

--- a/tests/test_varint.c
+++ b/tests/test_varint.c
@@ -14,7 +14,7 @@
 struct test_read_varint
 {
     /* Input: */
-#if __GNUC__
+#if __GNUC__ >= 8
     __attribute__((nonstring))
 #endif
     unsigned char       input[MAX_INPUT_SZ];


### PR DESCRIPTION
The `nonstring` attribute was introduced in GCC 8. This PR fixes compilation warnings by changing all instances of `#if __GNUC__` to `#if __GNUC__ >= 8` when using this attribute.

**Changes:**
- src/liblsquic/lsquic_tokgen.c
- src/liblsquic/lsquic_util.c
- tests/test_export_key.c
- tests/test_varint.c

**Testing:**
Clean build completed successfully with no warnings.