### PR TITLE
Fix include statement for vc_compat.h

### DIFF
--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -16,7 +16,7 @@
 #include <sys/uio.h>
 #include <time.h>
 #else
-#include <vc_compat.h>
+#include "vc_compat.h"
 #endif
 
 struct sockaddr;


### PR DESCRIPTION
compile error : 'vc_compat.h' file not found with <angled> include; use "quotes" instead