### PR TITLE
Release 4.6.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2026-04-27
+    - 4.6.3
+    - [FIX] Reject overlapping header sends, making code safer.
+    - [FIX] Follow spec: max datagram size of zero disables datagrams.
+    - [IMPROVEMENT] Include statement for vc_compat.h to use quotes.
+
 2026-04-20
     - 4.6.2
     - [FIX] Crash in shortcut IETF mini conn promotion.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = u'LiteSpeed Technologies'
 # The short X.Y version
 version = u'4.6'
 # The full version, including alpha/beta/rc tags
-release = u'4.6.2'
+release = u'4.6.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #define LSQUIC_MAJOR_VERSION 4
 #define LSQUIC_MINOR_VERSION 6
-#define LSQUIC_PATCH_VERSION 2
+#define LSQUIC_PATCH_VERSION 3
 
 #define LSQUIC_QUOTE(x)     #x
 #define LSQUIC_SVAL(v)      LSQUIC_QUOTE(v)

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -3686,7 +3686,8 @@ apply_trans_params (struct ietf_full_conn *conn,
         conn->ifc_flags |= IFC_TIMESTAMPS;
     }
     if (conn->ifc_settings->es_datagrams
-            && (params->tp_set & (1 << TPI_MAX_DATAGRAM_FRAME_SIZE)))
+            && (params->tp_set & (1 << TPI_MAX_DATAGRAM_FRAME_SIZE))
+            && params->tp_numerics[TPI_MAX_DATAGRAM_FRAME_SIZE] > 0)
     {
         LSQ_DEBUG("datagrams enabled");
         conn->ifc_flags |= IFC_DATAGRAMS;


### PR DESCRIPTION
- [FIX] Reject overlapping header sends, making code safer.
- [FIX] Follow spec: max datagram size of zero disables datagrams.
- [IMPROVEMENT] Include statement for vc_compat.h to use quotes.