### PR TITLE
Improve Early Hints header-set handling

### DIFF
--- a/bin/http_client.c
+++ b/bin/http_client.c
@@ -766,10 +766,43 @@ maybe_perform_priority_actions (struct lsquic_stream *stream,
 
 
 static void
+http_client_process_hset (lsquic_stream_t *stream, lsquic_stream_ctx_t *st_h)
+{
+    struct hset *hset;
+
+    hset = lsquic_stream_get_hset(stream);
+    if (!hset)
+    {
+        LSQ_ERROR("could not get header set from stream");
+        exit(2);
+    }
+    if (!(st_h->sh_flags & PROCESSED_HEADERS))
+    {
+        /* Internal helper (not in lsquic.h); example-only timing. */
+        st_h->sh_ttfb = lsquic_time_now();
+        update_sample_stats(&s_stat_ttfb, st_h->sh_ttfb - st_h->sh_created);
+        st_h->sh_flags |= PROCESSED_HEADERS;
+    }
+    if (s_discard_response)
+        LSQ_DEBUG("discard response: do not dump headers");
+    else
+        hset_dump(hset, stdout);
+    hset_destroy(hset);
+}
+
+
+static void
+http_client_on_hset_in (lsquic_stream_t *stream, lsquic_stream_ctx_t *st_h)
+{
+    if (g_header_bypass)
+        http_client_process_hset(stream, st_h);
+}
+
+
+static void
 http_client_on_read (lsquic_stream_t *stream, lsquic_stream_ctx_t *st_h)
 {
     struct http_client_ctx *const client_ctx = st_h->client_ctx;
-    struct hset *hset;
     ssize_t nread;
     unsigned old_prio, new_prio;
     unsigned char buf[0x200];
@@ -781,23 +814,7 @@ http_client_on_read (lsquic_stream_t *stream, lsquic_stream_ctx_t *st_h)
     do
     {
         if (g_header_bypass && !(st_h->sh_flags & PROCESSED_HEADERS))
-        {
-            hset = lsquic_stream_get_hset(stream);
-            if (!hset)
-            {
-                LSQ_ERROR("could not get header set from stream");
-                exit(2);
-            }
-            /* Internal helper (not in lsquic.h); example-only timing. */
-            st_h->sh_ttfb = lsquic_time_now();
-            update_sample_stats(&s_stat_ttfb, st_h->sh_ttfb - st_h->sh_created);
-            if (s_discard_response)
-                LSQ_DEBUG("discard response: do not dump headers");
-            else
-                hset_dump(hset, stdout);
-            hset_destroy(hset);
-            st_h->sh_flags |= PROCESSED_HEADERS;
-        }
+            http_client_process_hset(stream, st_h);
         else if (nread = (s_discard_response
                             ? lsquic_stream_readf(stream, discard, st_h)
                             : lsquic_stream_read(stream, buf,
@@ -955,6 +972,7 @@ static struct lsquic_stream_if http_client_if = {
     .on_write               = http_client_on_write,
     .on_close               = http_client_on_close,
     .on_hsk_done            = http_client_on_hsk_done,
+    .on_hset_in             = http_client_on_hset_in,
 };
 
 

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -1819,6 +1819,20 @@ more information.
 
         0 on success or -1 on error.
 
+    LSQUIC does not maintain a user-visible queue of header sets for this
+    function.  A stream can have at most one encoded header block pending in
+    the stream object.  If a previous call to this function produced a header
+    block that could not be written out completely, a subsequent call made
+    before that pending block is flushed fails with ``-1`` and sets ``errno``
+    to ``EBADMSG``.
+
+    This is intentional: queuing multiple outbound header sets internally
+    would create a second buffering layer with unclear ownership and resource
+    limits.  Applications that send more than one header set on a stream, for
+    example an informational response followed by the final response, should
+    serialize those calls and let LSQUIC flush the previous header block before
+    calling this function again.
+
 Receiving HTTP Headers
 ----------------------
 

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -1824,14 +1824,14 @@ more information.
     the stream object.  If a previous call to this function produced a header
     block that could not be written out completely, a subsequent call made
     before that pending block is flushed fails with ``-1`` and sets ``errno``
-    to ``EBADMSG``.
+    to ``EAGAIN``.
 
     This is intentional: queuing multiple outbound header sets internally
     would create a second buffering layer with unclear ownership and resource
     limits.  Applications that send more than one header set on a stream, for
     example an informational response followed by the final response, should
-    serialize those calls and let LSQUIC flush the previous header block before
-    calling this function again.
+    serialize those calls and retry after LSQUIC has flushed the previous
+    header block.
 
 Receiving HTTP Headers
 ----------------------

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -1381,6 +1381,21 @@ the engine to communicate with the user code:
 
         This callback is optional.
 
+    .. member:: void (*on_hset_in)  (lsquic_stream_t *s, lsquic_stream_ctx_t *h)
+
+        This callback is called when a decoded HTTP header set becomes
+        available on a stream.  It is only used when the optional header set
+        interface (:member:`lsquic_engine_api.ea_hsi_if`) is specified.
+
+        The application can call :func:`lsquic_stream_get_hset()` from this
+        callback to take ownership of the header set.  This is useful for
+        HTTP/3 responses that contain more than one header set, such as one or
+        more informational responses followed by the final response.
+
+        This callback is optional.  If it is not specified, header sets can
+        still be collected during the next :member:`lsquic_stream_if.on_read`
+        callback.
+
     .. member:: ssize_t (*on_dg_write)(lsquic_conn_t *c, void *buf, size_t buf_sz)
 
         Called when datagram is ready to be written.  Write at most
@@ -1888,6 +1903,10 @@ fields yourself.  In that case, the header set must be "read" from the stream vi
     Get header set associated with the stream.  The header set is created by
     ``hsi_create_header_set()`` callback.  After this call, the ownership of
     the header set is transferred to the caller.
+
+    When :member:`lsquic_stream_if.on_hset_in` is specified, the application
+    can call this function from that callback.  Otherwise, call this function
+    from :member:`lsquic_stream_if.on_read` before reading stream data.
 
     This call must precede calls to :func:`lsquic_stream_read()`,
     :func:`lsquic_stream_readv()`, and :func:`lsquic_stream_readf()`.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -333,7 +333,10 @@ this tutorial, it is good to know that they are available.
 - Callbacks to control memory allocation for outgoing packets.  These are useful when sending packets using a custom library.  For example, when all packets must be in contiguous memory.
 - Callbacks to observe connection ID lifecycle.  These are useful in multi-process applications.
 - Callbacks that provide access to a shared-memory hash.  This is also used in multi-process applications.
-- HTTP header set processing.  These callbacks may be used in HTTP mode for HTTP/3 and Google QUIC.
+- HTTP header set processing.  These callbacks may be used in HTTP mode for
+  HTTP/3 and Google QUIC.  The optional ``on_hset_in`` stream callback
+  notifies the application when a decoded header set is ready to be collected
+  using :func:`lsquic_stream_get_hset()`.
 
 Please refer to :ref:`apiref-engine-settings` for details.
 
@@ -365,6 +368,7 @@ The optional callbacks are used to observe some events in the connection lifecyc
       void (*on_hsk_done)(lsquic_conn_t *c, enum lsquic_hsk_status s);
       void (*on_new_token)(lsquic_conn_t *c, const unsigned char *token,
       void (*on_sess_resume_info)(lsquic_conn_t *c, const unsigned char *, size_t);
+      void (*on_hset_in)  (lsquic_stream_t *s, lsquic_stream_ctx_t *h);
   };
 
 On new connection

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -236,6 +236,11 @@ struct lsquic_stream_if {
     void (*on_conncloseframe_received)(lsquic_conn_t *c,
                                        int app_error, uint64_t error_code,
                                        const char *reason, int reason_len);
+    /**
+     * Optional callback is called when a new header set becomes available.
+     * The user may pick it off immediately using lsquic_stream_get_hset().
+     */
+    void (*on_hset_in)  (lsquic_stream_t *s, lsquic_stream_ctx_t *h);
 };
 
 struct ssl_ctx_st;

--- a/src/liblsquic/lsquic_full_conn.c
+++ b/src/liblsquic/lsquic_full_conn.c
@@ -4108,7 +4108,6 @@ synthesize_push_request (struct full_conn *conn, void *hset,
     if (lsquic_http1x_if == conn->fc_enpub->enp_hsi_if)
         uh->uh_flags    |= UH_H1H;
     uh->uh_hset          = hset;
-    uh->uh_next          = NULL;
 
     return uh;
 }

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -4165,7 +4165,6 @@ ietf_full_conn_ci_push_stream (struct lsquic_conn *lconn, void *hset,
     uh->uh_exclusive     = 0;
     uh->uh_flags         = UH_FIN;
     uh->uh_hset          = hset;
-    uh->uh_next          = NULL;
 
     memset(promise, 0, sizeof(*promise));
     promise->pp_refcnt = 1; /* This function itself keeps a reference */
@@ -10098,4 +10097,3 @@ static const struct lsquic_stream_if unicla_if =
 static const struct lsquic_stream_if *unicla_if_ptr = &unicla_if;
 
 typedef char dcid_elem_fits_in_128_bytes[sizeof(struct dcid_elem) <= 128 ? 1 : - 1];
-

--- a/src/liblsquic/lsquic_headers.h
+++ b/src/liblsquic/lsquic_headers.h
@@ -2,6 +2,8 @@
 #ifndef LSQUIC_HEADERS_H
 #define LSQUIC_HEADERS_H 1
 
+#include <sys/queue.h>
+
 /* When ea_hsi_if is not specified, the headers are converted to a C string
  * that contains HTTP/1.x-like header structure.
  */
@@ -36,8 +38,8 @@ struct uncompressed_headers
                            UH_H1H  = (1 << 2),  /* uh_hset points to http1x_headers */
     }                      uh_flags:8;
     void                  *uh_hset;
-    struct uncompressed_headers
-                          *uh_next;
+    STAILQ_ENTRY(uncompressed_headers)
+                           uh_next;
 };
 
 #endif

--- a/src/liblsquic/lsquic_headers.h
+++ b/src/liblsquic/lsquic_headers.h
@@ -2,8 +2,6 @@
 #ifndef LSQUIC_HEADERS_H
 #define LSQUIC_HEADERS_H 1
 
-#include <sys/queue.h>
-
 /* When ea_hsi_if is not specified, the headers are converted to a C string
  * that contains HTTP/1.x-like header structure.
  */

--- a/src/liblsquic/lsquic_headers.h
+++ b/src/liblsquic/lsquic_headers.h
@@ -2,6 +2,8 @@
 #ifndef LSQUIC_HEADERS_H
 #define LSQUIC_HEADERS_H 1
 
+#include <sys/queue.h>
+
 /* When ea_hsi_if is not specified, the headers are converted to a C string
  * that contains HTTP/1.x-like header structure.
  */

--- a/src/liblsquic/lsquic_http1x_if.c
+++ b/src/liblsquic/lsquic_http1x_if.c
@@ -192,6 +192,7 @@ code_str_to_reason (const char code_str[HTTP_CODE_LEN])
     #define HTTP_REASON_CODE(code, reason) [code - 100] = reason
         HTTP_REASON_CODE(100, "Continue"),
         HTTP_REASON_CODE(101, "Switching Protocols"),
+        HTTP_REASON_CODE(103, "Early Hints"),
         HTTP_REASON_CODE(200, "OK"),
         HTTP_REASON_CODE(201, "Created"),
         HTTP_REASON_CODE(202, "Accepted"),
@@ -240,7 +241,7 @@ code_str_to_reason (const char code_str[HTTP_CODE_LEN])
     memcpy(code_buf, code_str, HTTP_CODE_LEN);
     code_buf[HTTP_CODE_LEN] = '\0';
     code = strtol(code_buf, NULL, 10) - 100;
-    if (code > 0 && code < (long) (sizeof(http_reason_phrases) /
+    if (code >= 0 && code < (long) (sizeof(http_reason_phrases) /
                                         sizeof(http_reason_phrases[0])))
         return http_reason_phrases[code];
     else

--- a/src/liblsquic/lsquic_http1x_if.c
+++ b/src/liblsquic/lsquic_http1x_if.c
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/queue.h>
 
 #include "lsquic.h"
 #include "lsquic_headers.h"

--- a/src/liblsquic/lsquic_http1x_if.c
+++ b/src/liblsquic/lsquic_http1x_if.c
@@ -4,7 +4,6 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/queue.h>
 
 #include "lsquic.h"
 #include "lsquic_headers.h"

--- a/src/liblsquic/lsquic_stream.c
+++ b/src/liblsquic/lsquic_stream.c
@@ -416,6 +416,7 @@ stream_new_common (lsquic_stream_id_t id, struct lsquic_conn_public *conn_pub,
     stream->sm_write_avail = stream_write_avail_no_frames;
 
     STAILQ_INIT(&stream->sm_hq_frames);
+    STAILQ_INIT(&stream->uh);
 
     stream->sm_bflags |= ctor_flags & ((1 << N_SMBF_FLAGS) - 1);
     if (conn_pub->lconn->cn_flags & LSCONN_SERVER)
@@ -613,8 +614,8 @@ drop_buffered_data (struct lsquic_stream *stream)
 void
 lsquic_stream_drop_hset_ref (struct lsquic_stream *stream)
 {
-    if (stream->uh)
-        stream->uh->uh_hset = NULL;
+    if (!STAILQ_EMPTY(&stream->uh))
+        STAILQ_FIRST(&stream->uh)->uh_hset = NULL;
 }
 
 
@@ -682,10 +683,9 @@ lsquic_stream_destroy (lsquic_stream_t *stream)
     }
     while ((shf = STAILQ_FIRST(&stream->sm_hq_frames)))
         stream_hq_frame_put(stream, shf);
-    while(stream->uh)
+    while ((uh = STAILQ_FIRST(&stream->uh)))
     {
-        uh = stream->uh;
-        stream->uh = uh->uh_next;
+        STAILQ_REMOVE_HEAD(&stream->uh, uh_next);
         destroy_uh(uh, stream->conn_pub->enpub->enp_hsi_if);
     }
     free(stream->sm_buf);
@@ -810,7 +810,7 @@ static int
 stream_readable_http_gquic (struct lsquic_stream *stream)
 {
     return (stream->stream_flags & STREAM_HAVE_UH)
-        && (stream->uh
+        && (!STAILQ_EMPTY(&stream->uh)
             || stream_has_frame_at_read_offset(stream));
 }
 
@@ -822,7 +822,7 @@ stream_readable_http_ietf (struct lsquic_stream *stream)
         /* If we have read the header set and the header set has not yet
          * been read, the stream is readable.
          */
-        ((stream->stream_flags & STREAM_HAVE_UH) && stream->uh)
+        ((stream->stream_flags & STREAM_HAVE_UH) && !STAILQ_EMPTY(&stream->uh))
         ||
         /* Alternatively, run the filter and check for payload availability. */
         (stream->sm_sfi->sfi_readable(stream)
@@ -1457,7 +1457,7 @@ static size_t
 read_uh (struct lsquic_stream *stream,
         size_t (*readf)(void *, const unsigned char *, size_t, int), void *ctx)
 {
-    struct uncompressed_headers *uh = stream->uh;
+    struct uncompressed_headers *uh = STAILQ_FIRST(&stream->uh);
     struct http1x_headers *const h1h = uh->uh_hset;
     size_t nread;
 
@@ -1467,9 +1467,9 @@ read_uh (struct lsquic_stream *stream,
     h1h->h1h_off += nread;
     if (h1h->h1h_off == h1h->h1h_size)
     {
-        stream->uh = uh->uh_next;
+        STAILQ_REMOVE_HEAD(&stream->uh, uh_next);
         LSQ_DEBUG("read all uncompressed headers from uh: %p, next uh: %p",
-                    uh, stream->uh);
+                    uh, STAILQ_FIRST(&stream->uh));
         destroy_uh(uh, stream->conn_pub->enpub->enp_hsi_if);
         if (stream->stream_flags & STREAM_HEAD_IN_FIN)
         {
@@ -1600,7 +1600,7 @@ stream_readf (struct lsquic_stream *stream,
     if ((stream->sm_bflags & (SMBF_USE_HEADERS|SMBF_IETF))
                                             == (SMBF_USE_HEADERS|SMBF_IETF)
             && !(stream->stream_flags & STREAM_HAVE_UH)
-            && !stream->uh)
+            && STAILQ_EMPTY(&stream->uh))
     {
         if (stream->sm_readable(stream))
         {
@@ -1611,7 +1611,7 @@ stream_readf (struct lsquic_stream *stream,
                 return -1;
             }
 
-            if (!stream->uh)
+            if (STAILQ_EMPTY(&stream->uh))
             {
                 LSQ_DEBUG("cannot read: headers not available");
                 errno = EBADMSG;
@@ -1625,12 +1625,12 @@ stream_readf (struct lsquic_stream *stream,
         }
     }
 
-    if (stream->uh)
+    if (!STAILQ_EMPTY(&stream->uh))
     {
-        if (stream->uh->uh_flags & UH_H1H)
+        if (STAILQ_FIRST(&stream->uh)->uh_flags & UH_H1H)
         {
             total_nread += read_uh(stream, readf, ctx);
-            if (stream->uh)
+            if (!STAILQ_EMPTY(&stream->uh))
                 return total_nread;
         }
         else
@@ -1694,7 +1694,8 @@ lsquic_stream_readf (struct lsquic_stream *stream,
     {
        if (stream->sm_bflags & SMBF_USE_HEADERS)
        {
-            if ((stream->stream_flags & STREAM_HAVE_UH) && !stream->uh)
+            if ((stream->stream_flags & STREAM_HAVE_UH)
+                                            && STAILQ_EMPTY(&stream->uh))
                 return 0;
        }
        else
@@ -4508,7 +4509,6 @@ static int
 stream_uh_in_gquic (struct lsquic_stream *stream,
                                             struct uncompressed_headers *uh)
 {
-    struct uncompressed_headers **next;
     if ((stream->sm_bflags & SMBF_USE_HEADERS))
     {
         SM_HISTORY_APPEND(stream, SHE_HEADERS_IN);
@@ -4516,11 +4516,8 @@ stream_uh_in_gquic (struct lsquic_stream *stream,
         stream->stream_flags |= STREAM_HAVE_UH;
         if (uh->uh_flags & UH_FIN)
             stream->stream_flags |= STREAM_FIN_RECVD|STREAM_HEAD_IN_FIN;
-        next = &stream->uh;
-        while(*next)
-            next = &(*next)->uh_next;
-        *next = uh;
-        assert(uh->uh_next == NULL);
+        STAILQ_INSERT_TAIL(&stream->uh, uh, uh_next);
+        assert(STAILQ_NEXT(uh, uh_next) == NULL);
         if (uh->uh_oth_stream_id == 0)
         {
             if (uh->uh_weight)
@@ -4544,7 +4541,6 @@ stream_uh_in_ietf (struct lsquic_stream *stream,
                                             struct uncompressed_headers *uh)
 {
     int push_promise;
-    struct uncompressed_headers **next;
 
     push_promise = lsquic_stream_header_is_pp(stream);
     if (!push_promise)
@@ -4562,11 +4558,8 @@ stream_uh_in_ietf (struct lsquic_stream *stream,
                                             && lsquic_stream_is_pushed(stream));
             stream->stream_flags |= STREAM_FIN_RECVD|STREAM_HEAD_IN_FIN;
         }
-        next = &stream->uh;
-        while(*next)
-            next = &(*next)->uh_next;
-        *next = uh;
-        assert(uh->uh_next == NULL);
+        STAILQ_INSERT_TAIL(&stream->uh, uh, uh_next);
+        assert(STAILQ_NEXT(uh, uh_next) == NULL);
         if (uh->uh_oth_stream_id == 0)
         {
             if (uh->uh_weight)
@@ -4782,17 +4775,17 @@ lsquic_stream_get_hset (struct lsquic_stream *stream)
         return NULL;
     }
 
-    if (!stream->uh)
+    if (STAILQ_EMPTY(&stream->uh))
     {
         LSQ_INFO("%s: headers unavailable (already fetched?)", __func__);
         return NULL;
     }
 
-    hset = stream->uh->uh_hset;
-    stream->uh->uh_hset = NULL;
+    uh = STAILQ_FIRST(&stream->uh);
+    hset = uh->uh_hset;
+    uh->uh_hset = NULL;
 
-    uh = stream->uh;
-    stream->uh = uh->uh_next;
+    STAILQ_REMOVE_HEAD(&stream->uh, uh_next);
     free(uh);
 
     if (stream->stream_flags & STREAM_HEAD_IN_FIN)
@@ -5119,7 +5112,7 @@ hq_filter_readable_now (const struct lsquic_stream *stream)
     return (filter->hqfi_type == HQFT_DATA
                     && filter->hqfi_state == HQFI_STATE_READING_PAYLOAD)
         || (filter->hqfi_flags & HQFI_FLAG_ERROR)
-        || stream->uh
+        || !STAILQ_EMPTY(&stream->uh)
         || (stream->stream_flags & STREAM_FIN_REACHED)
     ;
 }

--- a/src/liblsquic/lsquic_stream.c
+++ b/src/liblsquic/lsquic_stream.c
@@ -1527,7 +1527,7 @@ read_data_frames (struct lsquic_stream *stream, int do_filtering,
 {
     struct data_frame *data_frame;
     size_t nread, toread, total_nread;
-    int short_read, processed_frames, stop_for_hset;
+    int short_read, processed_frames;
 
     processed_frames = 0;
     total_nread = 0;
@@ -1540,23 +1540,10 @@ read_data_frames (struct lsquic_stream *stream, int do_filtering,
 
         do
         {
-            stop_for_hset = 0;
             if (do_filtering && stream->sm_sfi)
                 toread = stream->sm_sfi->sfi_filter_df(stream, data_frame);
             else
                 toread = data_frame->df_size - data_frame->df_read_off;
-
-            if (do_filtering
-                && (stream->sm_bflags & (SMBF_USE_HEADERS|SMBF_IETF))
-                                        == (SMBF_USE_HEADERS|SMBF_IETF)
-                && !STAILQ_EMPTY(&stream->uh)
-                && !(STAILQ_FIRST(&stream->uh)->uh_flags & UH_H1H))
-            {
-                /* DATA must not overtake an unclaimed HTTP/3 header set. */
-                stop_for_hset = 1;
-                if (toread || data_frame->df_read_off < data_frame->df_size)
-                    goto end_while;
-            }
 
             if (toread || data_frame->df_fin)
             {
@@ -1586,8 +1573,6 @@ read_data_frames (struct lsquic_stream *stream, int do_filtering,
                         verify_cl_on_fin(stream);
                     goto end_while;
                 }
-                if (stop_for_hset)
-                    goto end_while;
             }
             else if (short_read)
                 goto end_while;

--- a/src/liblsquic/lsquic_stream.c
+++ b/src/liblsquic/lsquic_stream.c
@@ -4527,6 +4527,8 @@ stream_uh_in_gquic (struct lsquic_stream *stream,
         else
             LSQ_NOTICE("don't know how to depend on stream %"PRIu64,
                                                         uh->uh_oth_stream_id);
+        if (stream->stream_if->on_hset_in)
+            stream->stream_if->on_hset_in(stream, stream->st_ctx);
         return 0;
     }
     else

--- a/src/liblsquic/lsquic_stream.c
+++ b/src/liblsquic/lsquic_stream.c
@@ -4519,7 +4519,6 @@ stream_uh_in_gquic (struct lsquic_stream *stream,
         if (uh->uh_flags & UH_FIN)
             stream->stream_flags |= STREAM_FIN_RECVD|STREAM_HEAD_IN_FIN;
         STAILQ_INSERT_TAIL(&stream->uh, uh, uh_next);
-        assert(STAILQ_NEXT(uh, uh_next) == NULL);
         if (uh->uh_oth_stream_id == 0)
         {
             if (uh->uh_weight)
@@ -4561,7 +4560,6 @@ stream_uh_in_ietf (struct lsquic_stream *stream,
             stream->stream_flags |= STREAM_FIN_RECVD|STREAM_HEAD_IN_FIN;
         }
         STAILQ_INSERT_TAIL(&stream->uh, uh, uh_next);
-        assert(STAILQ_NEXT(uh, uh_next) == NULL);
         if (uh->uh_oth_stream_id == 0)
         {
             if (uh->uh_weight)

--- a/src/liblsquic/lsquic_stream.c
+++ b/src/liblsquic/lsquic_stream.c
@@ -2155,8 +2155,7 @@ struct progress
 {
     enum stream_flags   s_flags;
     enum stream_q_flags q_flags;
-    const struct uncompressed_headers
-                       *uh;
+    uintptr_t           uh;
 };
 
 
@@ -2168,7 +2167,7 @@ stream_progress (const struct lsquic_stream *stream)
           & (STREAM_U_WRITE_DONE|STREAM_U_READ_DONE),
         .q_flags = stream->sm_qflags
           & (SMQF_WANT_READ|SMQF_WANT_WRITE|SMQF_WANT_FLUSH|SMQF_SEND_RST),
-        .uh = STAILQ_FIRST(&stream->uh),
+        .uh = (uintptr_t) STAILQ_FIRST(&stream->uh),
     };
 }
 

--- a/src/liblsquic/lsquic_stream.c
+++ b/src/liblsquic/lsquic_stream.c
@@ -1527,7 +1527,7 @@ read_data_frames (struct lsquic_stream *stream, int do_filtering,
 {
     struct data_frame *data_frame;
     size_t nread, toread, total_nread;
-    int short_read, processed_frames;
+    int short_read, processed_frames, stop_for_hset;
 
     processed_frames = 0;
     total_nread = 0;
@@ -1540,10 +1540,23 @@ read_data_frames (struct lsquic_stream *stream, int do_filtering,
 
         do
         {
+            stop_for_hset = 0;
             if (do_filtering && stream->sm_sfi)
                 toread = stream->sm_sfi->sfi_filter_df(stream, data_frame);
             else
                 toread = data_frame->df_size - data_frame->df_read_off;
+
+            if (do_filtering
+                && (stream->sm_bflags & (SMBF_USE_HEADERS|SMBF_IETF))
+                                        == (SMBF_USE_HEADERS|SMBF_IETF)
+                && !STAILQ_EMPTY(&stream->uh)
+                && !(STAILQ_FIRST(&stream->uh)->uh_flags & UH_H1H))
+            {
+                /* DATA must not overtake an unclaimed HTTP/3 header set. */
+                stop_for_hset = 1;
+                if (toread || data_frame->df_read_off < data_frame->df_size)
+                    goto end_while;
+            }
 
             if (toread || data_frame->df_fin)
             {
@@ -1573,6 +1586,8 @@ read_data_frames (struct lsquic_stream *stream, int do_filtering,
                         verify_cl_on_fin(stream);
                     goto end_while;
                 }
+                if (stop_for_hset)
+                    goto end_while;
             }
             else if (short_read)
                 goto end_while;
@@ -2155,6 +2170,8 @@ struct progress
 {
     enum stream_flags   s_flags;
     enum stream_q_flags q_flags;
+    const struct uncompressed_headers
+                       *uh;
 };
 
 
@@ -2166,6 +2183,7 @@ stream_progress (const struct lsquic_stream *stream)
           & (STREAM_U_WRITE_DONE|STREAM_U_READ_DONE),
         .q_flags = stream->sm_qflags
           & (SMQF_WANT_READ|SMQF_WANT_WRITE|SMQF_WANT_FLUSH|SMQF_SEND_RST),
+        .uh = STAILQ_FIRST(&stream->uh),
     };
 }
 
@@ -2173,7 +2191,7 @@ stream_progress (const struct lsquic_stream *stream)
 static int
 progress_eq (struct progress a, struct progress b)
 {
-    return a.s_flags == b.s_flags && a.q_flags == b.q_flags;
+    return a.s_flags == b.s_flags && a.q_flags == b.q_flags && a.uh == b.uh;
 }
 
 
@@ -4568,6 +4586,8 @@ stream_uh_in_ietf (struct lsquic_stream *stream,
         else
             LSQ_NOTICE("don't know how to depend on stream %"PRIu64,
                                                         uh->uh_oth_stream_id);
+        if (stream->stream_if->on_hset_in)
+            stream->stream_if->on_hset_in(stream, stream->st_ctx);
     }
     else
     {

--- a/src/liblsquic/lsquic_stream.h
+++ b/src/liblsquic/lsquic_stream.h
@@ -312,8 +312,9 @@ struct lsquic_stream
     /* Last offset sent in BLOCKED frame */
     uint64_t                        blocked_off;
 
-    struct uncompressed_headers    *uh,
-                                   *push_req;
+    STAILQ_HEAD(, uncompressed_headers)
+                                    uh;
+    struct uncompressed_headers    *push_req;
     union hblock_ctx               *sm_hblock_ctx;
 
     unsigned char                  *sm_buf;

--- a/tests/test_send_headers.c
+++ b/tests/test_send_headers.c
@@ -65,6 +65,9 @@
 static int s_call_wantwrite_in_ctor;
 static int s_wantwrite_arg;
 static int s_onwrite_called;
+static unsigned s_on_hset_in_count;
+static struct lsquic_stream *s_on_hset_in_stream;
+static lsquic_stream_ctx_t *s_on_hset_in_ctx;
 
 static lsquic_stream_ctx_t *
 on_new_stream (void *stream_if_ctx, lsquic_stream_t *stream)
@@ -102,11 +105,29 @@ on_reset (lsquic_stream_t *stream, lsquic_stream_ctx_t *h, int how)
 }
 
 
+static void
+on_hset_in (lsquic_stream_t *stream, lsquic_stream_ctx_t *h)
+{
+    ++s_on_hset_in_count;
+    s_on_hset_in_stream = stream;
+    s_on_hset_in_ctx = h;
+}
+
+
 const struct lsquic_stream_if stream_if = {
     .on_new_stream          = on_new_stream,
     .on_write               = on_write,
     .on_close               = on_close,
     .on_reset               = on_reset,
+};
+
+
+const struct lsquic_stream_if stream_if_on_hset = {
+    .on_new_stream          = on_new_stream,
+    .on_write               = on_write,
+    .on_close               = on_close,
+    .on_reset               = on_reset,
+    .on_hset_in             = on_hset_in,
 };
 
 
@@ -685,6 +706,55 @@ test_read_headers (int ietf, int use_hset)
 
 
 static void
+test_multiple_hsets_fifo (void)
+{
+    struct test_objs tobjs;
+    struct lsquic_stream *stream;
+    struct uncompressed_headers *uh;
+    char hsets[3];
+    void *hset;
+    unsigned i;
+    int s;
+
+    init_test_objs(&tobjs, 0x1000, 0x1000, SCF_IETF);
+    tobjs.stream_if = &stream_if_on_hset;
+
+    s_on_hset_in_count = 0;
+    s_on_hset_in_stream = NULL;
+    s_on_hset_in_ctx = NULL;
+
+    stream = new_stream(&tobjs, 4 * __LINE__, 0x1000);
+
+    for (i = 0; i < sizeof(hsets); ++i)
+    {
+        uh = calloc(1, sizeof(*uh));
+        *uh = (struct uncompressed_headers) {
+            .uh_stream_id   = stream->id,
+            .uh_weight      = 127,
+            .uh_hset        = &hsets[i],
+        };
+        s = lsquic_stream_uh_in(stream, uh);
+        assert(s == 0);
+        assert(s_on_hset_in_count == i + 1);
+        assert(s_on_hset_in_stream == stream);
+        assert(s_on_hset_in_ctx == NULL);
+    }
+
+    for (i = 0; i < sizeof(hsets); ++i)
+    {
+        hset = lsquic_stream_get_hset(stream);
+        assert(hset == &hsets[i]);
+    }
+    hset = lsquic_stream_get_hset(stream);
+    assert(hset == NULL);
+
+    lsquic_stream_destroy(stream);
+
+    deinit_test_objs(&tobjs);
+}
+
+
+static void
 test_read_headers_http1x (void)
 {
     struct test_objs tobjs;
@@ -754,6 +824,7 @@ main (int argc, char **argv)
     test_read_headers(0, 1);
     test_read_headers(1, 0);
     test_read_headers(1, 1);
+    test_multiple_hsets_fifo();
     test_read_headers_http1x();
 
     return 0;

--- a/tests/test_send_headers.c
+++ b/tests/test_send_headers.c
@@ -755,28 +755,32 @@ test_multiple_hsets_fifo (void)
 
 
 static void
-test_read_headers_http1x (void)
+test_read_headers_http1x_case (const unsigned char *field_line,
+                                    size_t field_line_sz, const char *expected)
 {
     struct test_objs tobjs;
     struct lsquic_stream *stream;
     struct stream_frame *frame;
     int s;
-    const unsigned char headers_frame[5] = {
-        0x01,   /* Headers frame */
-        0x03,   /* Frame length */
-        0x00,
-        0x00,
-        0xC0 | 25   /* :status 200 */,
-    };
+    unsigned char headers_frame[0x10];
     ssize_t nr;
     unsigned char buf[0x100];
+
+    assert(2 + field_line_sz < 0x40);
+    assert(2 + 2 + field_line_sz <= sizeof(headers_frame));
+
+    headers_frame[0] = 0x01; /* Headers frame */
+    headers_frame[1] = 2 + field_line_sz; /* Frame length */
+    headers_frame[2] = 0x00;
+    headers_frame[3] = 0x00;
+    memcpy(headers_frame + 4, field_line, field_line_sz);
 
     init_test_objs(&tobjs, 0x1000, 0x1000, SCF_IETF);
 
     stream = new_stream(&tobjs, 0, 0x1000);
-    frame = new_frame_in(&tobjs, 0, sizeof(headers_frame), 1);
+    frame = new_frame_in(&tobjs, 0, 4 + field_line_sz, 1);
     memcpy((unsigned char *) frame->data_frame.df_data, headers_frame,
-                                                    sizeof(headers_frame));
+                                                    4 + field_line_sz);
     s = lsquic_stream_frame_in(stream, frame);
     assert(s == 0);
 
@@ -785,12 +789,34 @@ test_read_headers_http1x (void)
 
     nr = lsquic_stream_read(stream, buf, sizeof(buf));
     assert(nr > 0);
-    assert(nr == 19);
-    assert(0 == memcmp(buf, "HTTP/1.1 200 OK\r\n\r\n", nr));
+    assert(nr == (ssize_t) strlen(expected));
+    assert(0 == memcmp(buf, expected, nr));
 
     lsquic_stream_destroy(stream);
 
     deinit_test_objs(&tobjs);
+}
+
+
+static void
+test_read_headers_http1x (void)
+{
+    const unsigned char status_100[] = {
+        0xC0 | 63, 0x00,  /* :status 100 */
+    };
+    const unsigned char status_103[] = {
+        0xC0 | 24,        /* :status 103 */
+    };
+    const unsigned char status_200[] = {
+        0xC0 | 25,        /* :status 200 */
+    };
+
+    test_read_headers_http1x_case(status_100, sizeof(status_100),
+                                        "HTTP/1.1 100 Continue\r\n\r\n");
+    test_read_headers_http1x_case(status_103, sizeof(status_103),
+                                        "HTTP/1.1 103 Early Hints\r\n\r\n");
+    test_read_headers_http1x_case(status_200, sizeof(status_200),
+                                        "HTTP/1.1 200 OK\r\n\r\n");
 }
 
 

--- a/tests/test_send_headers.c
+++ b/tests/test_send_headers.c
@@ -747,7 +747,7 @@ test_read_headers (int ietf, int use_hset)
 
 
 static void
-test_multiple_hsets_fifo (void)
+test_multiple_hsets_fifo (int ietf)
 {
     struct test_objs tobjs;
     struct lsquic_stream *stream;
@@ -757,7 +757,7 @@ test_multiple_hsets_fifo (void)
     unsigned i;
     int s;
 
-    init_test_objs(&tobjs, 0x1000, 0x1000, SCF_IETF);
+    init_test_objs(&tobjs, 0x1000, 0x1000, ietf ? SCF_IETF : 0);
     tobjs.stream_if = &stream_if_on_hset;
 
     s_on_hset_in_count = 0;
@@ -892,7 +892,8 @@ main (int argc, char **argv)
     test_read_headers(0, 1);
     test_read_headers(1, 0);
     test_read_headers(1, 1);
-    test_multiple_hsets_fifo();
+    test_multiple_hsets_fifo(0);
+    test_multiple_hsets_fifo(1);
     test_read_headers_http1x();
 
     return 0;


### PR DESCRIPTION
This PR improves support for multiple HTTP header sets on a stream, which is needed for responses such as `103 Early Hints` followed by a final response.  Incoming header sets are now kept in an internal queue and applications can opt into the new `on_hset_in` callback to be notified as each decoded header set becomes available.  Header-bypass users can then call `lsquic_stream_get_hset()` from that callback instead of relying on `on_read()` and inferring header availability from status codes.

The receive-side change is limited to header-set delivery and progress accounting: consuming a queued header set now counts as read progress, but the existing DATA read behavior is preserved.  A separate API question about whether unclaimed HTTP/3 header sets should block DATA delivery is tracked in #638.

The send side continues to allow only one pending encoded header block per stream.  That behavior is now documented explicitly because buffering multiple outbound header sets internally would create another queue with unclear ownership and resource limits; applications should serialize multiple calls to `lsquic_stream_send_headers()` and wait for the previous header block to flush.

The HTTP/1.x compatibility converter now recognizes informational reason phrases for `100 Continue` and `103 Early Hints`, so converted responses no longer omit those standard reason phrases.

Fixes #635