### PR TITLE
Refactor: drop mini-conn promotion shortcut

### DIFF
--- a/bin/test_common.c
+++ b/bin/test_common.c
@@ -2248,6 +2248,11 @@ set_engine_option (struct lsquic_engine_settings *settings,
         }
         break;
     case 24:
+        if (0 == strncmp(name, "max_delayed_0rtt_packets", 24))
+        {
+            settings->es_max_delayed_0rtt_packets = atoi(val);
+            return 0;
+        }
         if (0 == strncmp(name, "init_max_stream_data_uni", 24))
         {
             settings->es_init_max_stream_data_uni = atoi(val);

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -899,6 +899,16 @@ settings structure:
 
        Default value is :macro:`LSQUIC_DF_MAX_BATCH_SIZE`
 
+    .. member:: unsigned        es_max_delayed_0rtt_packets
+
+       Maximum number of 0-RTT packets a server-side mini connection will
+       delay after the handshake has completed and promotion to a full
+       connection is pending.
+
+       This setting is applicable to IETF QUIC servers only.
+
+       Default value is :macro:`LSQUIC_DF_MAX_DELAYED_0RTT_PACKETS`
+
     .. member:: int             es_check_tp_sanity
 
        When true, sanity checks are performed on peer's transport parameter
@@ -1147,6 +1157,11 @@ out of date.  Please check your :file:`lsquic.h` for actual values.*
 
     By default, maximum batch size is not specified, leaving it up to the
     library.
+
+.. macro:: LSQUIC_DF_MAX_DELAYED_0RTT_PACKETS
+
+    By default, a server-side mini connection delays up to 32 0-RTT packets
+    while promotion to a full connection is pending.
 
 .. macro:: LSQUIC_DF_CHECK_TP_SANITY
 

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -466,6 +466,9 @@ typedef struct ssl_ctx_st * (*lsquic_lookup_cert_f)(
  */
 #define LSQUIC_DF_MAX_BATCH_SIZE 0
 
+/** Default number of 0-RTT packets to delay while promotion is pending. */
+#define LSQUIC_DF_MAX_DELAYED_0RTT_PACKETS 32
+
 /** Transport parameter sanity checks are performed by default. */
 #define LSQUIC_DF_CHECK_TP_SANITY 1
 
@@ -1124,6 +1127,15 @@ struct lsquic_engine_settings {
      * Default value is @ref LSQUIC_DF_MAX_BATCH_SIZE
      */
     unsigned        es_max_batch_size;
+
+    /**
+     * Maximum number of 0-RTT packets a server-side mini connection will
+     * delay after the handshake has completed and promotion to a full
+     * connection is pending.
+     *
+     * Default value is @ref LSQUIC_DF_MAX_DELAYED_0RTT_PACKETS.
+     */
+    unsigned        es_max_delayed_0rtt_packets;
 
     /**
      * When true, sanity checks are performed on peer's transport parameter

--- a/src/liblsquic/lsquic_conn.h
+++ b/src/liblsquic/lsquic_conn.h
@@ -40,7 +40,7 @@ enum lsquic_conn_flags {
     LSCONN_HASHED         = (1 << 2),
     LSCONN_MINI           = (1 << 3),   /* This is a mini connection */
     LSCONN_IMMED_CLOSE    = (1 << 4),
-    LSCONN_PROMOTE_FAIL   = (1 << 5),
+    LSCONN_UNUSED_5       = (1 << 5),
     LSCONN_HANDSHAKE_DONE = (1 << 6),
     LSCONN_CLOSING        = (1 << 7),
     LSCONN_PEER_GOING_AWAY= (1 << 8),

--- a/src/liblsquic/lsquic_engine.c
+++ b/src/liblsquic/lsquic_engine.c
@@ -403,6 +403,8 @@ lsquic_engine_init_settings (struct lsquic_engine_settings *settings,
     settings->es_ptpc_err_thresh = LSQUIC_DF_PTPC_ERR_THRESH;
     settings->es_ptpc_err_divisor= LSQUIC_DF_PTPC_ERR_DIVISOR;
     settings->es_delay_onclose   = LSQUIC_DF_DELAY_ONCLOSE;
+    settings->es_max_delayed_0rtt_packets
+                              = LSQUIC_DF_MAX_DELAYED_0RTT_PACKETS;
     settings->es_check_tp_sanity = LSQUIC_DF_CHECK_TP_SANITY;
     settings->es_amp_factor      = LSQUIC_DF_AMP_FACTOR;
     settings->es_send_verneg     = LSQUIC_DF_SEND_VERNEG;
@@ -502,6 +504,15 @@ lsquic_engine_check_settings (const struct lsquic_engine_settings *settings,
         if (err_buf)
             snprintf(err_buf, err_buf_sz, "max batch size is greater than "
                 "the allowed maximum of %u", (unsigned) MAX_OUT_BATCH_SIZE);
+        return -1;
+    }
+
+    if (settings->es_max_delayed_0rtt_packets > UCHAR_MAX)
+    {
+        if (err_buf)
+            snprintf(err_buf, err_buf_sz, "max delayed 0-RTT packet count "
+                "is greater than the allowed maximum of %u",
+                (unsigned) UCHAR_MAX);
         return -1;
     }
 #if LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
@@ -1198,50 +1209,6 @@ new_full_conn_server (lsquic_engine_t *engine, lsquic_conn_t *mini_conn,
 }
 
 
-static void
-remove_conn_from_hash (lsquic_engine_t *engine, lsquic_conn_t *conn);
-
-
-static int
-promote_mini_conn (lsquic_engine_t *engine, lsquic_conn_t *mini_conn,
-                                                        lsquic_time_t now)
-{
-    lsquic_conn_t *new_conn;
-    EV_LOG_CONN_EVENT(lsquic_conn_log_cid( mini_conn ),
-                                        "promote to full conn");
-    assert( mini_conn->cn_flags & LSCONN_MINI);
-
-    lsquic_mini_conn_ietf_pre_promote((struct ietf_mini_conn *)mini_conn, now);
-
-    new_conn = new_full_conn_server(engine, mini_conn, now);
-    if (new_conn)
-    {
-        new_conn->cn_last_sent = engine->last_sent;
-        eng_hist_inc(&engine->history, now, sl_new_full_conns);
-        mini_conn->cn_flags |= LSCONN_PROMOTED;
-        assert(engine->curr_conn == mini_conn);
-        engine->curr_conn = new_conn;
-
-        if (mini_conn->cn_flags & LSCONN_ATTQ)
-        {
-            lsquic_attq_remove(engine->attq, mini_conn);
-            (void) engine_decref_conn(engine, mini_conn, LSCONN_ATTQ);
-        }
-        if (mini_conn->cn_flags & LSCONN_HASHED)
-            remove_conn_from_hash(engine, mini_conn);
-
-        if (!(new_conn->cn_flags & LSCONN_TICKABLE))
-        {
-            lsquic_mh_insert(&engine->conns_tickable, new_conn,
-                            new_conn->cn_last_ticked);
-            engine_incref_conn(new_conn, LSCONN_TICKABLE);
-        }
-        return 0;
-    }
-    return -1;
-}
-
-
 static enum
 {
     VER_NOT_SPECIFIED,
@@ -1805,12 +1772,6 @@ process_packet_in (lsquic_engine_t *engine, lsquic_packet_in_t *packet_in,
 #endif
     QLOG_PACKET_RX(lsquic_conn_log_cid(conn), packet_in, packet_in_data, packet_in_size);
     lsquic_packet_in_put(&engine->pub.enp_mm, packet_in);
-    if ((conn->cn_flags & (LSCONN_MINI | LSCONN_HANDSHAKE_DONE | LSCONN_IETF | LSCONN_PROMOTE_FAIL))
-                    == (LSCONN_MINI | LSCONN_HANDSHAKE_DONE | LSCONN_IETF))
-    {
-        if (promote_mini_conn(engine, conn, lsquic_time_now()) == -1)
-            conn->cn_flags |= LSCONN_PROMOTE_FAIL;
-    }
     return 0;
 }
 

--- a/src/liblsquic/lsquic_mini_conn_ietf.c
+++ b/src/liblsquic/lsquic_mini_conn_ietf.c
@@ -1533,7 +1533,10 @@ imico_maybe_delay_processing (struct ietf_mini_conn *conn,
 {
     unsigned max_delayed;
 
-    if (conn->imc_flags & IMC_ADDR_VALIDATED)
+    if (conn->imc_flags & IMC_HSK_OK)
+        max_delayed =
+            conn->imc_enpub->enp_settings.es_max_delayed_0rtt_packets;
+    else if (conn->imc_flags & IMC_ADDR_VALIDATED)
         max_delayed = IMICO_MAX_DELAYED_PACKETS_VALIDATED;
     else
         max_delayed = IMICO_MAX_DELAYED_PACKETS_UNVALIDATED;
@@ -1691,13 +1694,6 @@ ietf_mini_conn_ci_packet_in (struct lsquic_conn *lconn,
      */
     conn->imc_bytes_in += packet_in->pi_data_sz;
     conn->imc_flags &= ~IMC_AMP_CAPPED;
-
-    if (lconn->cn_enc_session == NULL)
-    {
-        assert(lconn->cn_flags & LSCONN_PROMOTE_FAIL);
-        LSQ_DEBUG("ignore incoming packet: crypto session gone (promotion failed?)");
-        return;
-    }
 
     if (conn->imc_flags & IMC_ERROR)
     {
@@ -2139,22 +2135,6 @@ imico_generate_acks (struct ietf_mini_conn *conn, lsquic_time_t now)
 }
 
 
-int
-lsquic_mini_conn_ietf_pre_promote(struct ietf_mini_conn *conn,
-                                  lsquic_time_t now)
-{
-    if (conn->imc_flags & (IMC_QUEUED_ACK_INIT|IMC_QUEUED_ACK_HSK))
-    {
-        if (0 != imico_generate_acks(conn, now))
-        {
-            conn->imc_flags |= IMC_ERROR;
-            return -1;
-        }
-    }
-    return 0;
-}
-
-
 static void
 imico_generate_conn_close (struct ietf_mini_conn *conn)
 {
@@ -2334,8 +2314,7 @@ ietf_mini_conn_ci_tick (struct lsquic_conn *lconn, lsquic_time_t now)
     struct ietf_mini_conn *conn = (struct ietf_mini_conn *) lconn;
     enum tick_st tick;
 
-    /* Shortcut promotion: all ticks are now off */
-    if (lconn->cn_flags & (LSCONN_PROMOTED|LSCONN_PROMOTE_FAIL))
+    if (lconn->cn_flags & LSCONN_PROMOTED)
         return TICK_CLOSE;
 
     if (conn->imc_expire < now)

--- a/src/liblsquic/lsquic_mini_conn_ietf.h
+++ b/src/liblsquic/lsquic_mini_conn_ietf.h
@@ -164,8 +164,4 @@ lsquic_imico_rechist_first (void *rechist_ctx);
 const struct lsquic_packno_range *
 lsquic_imico_rechist_next (void *rechist_ctx);
 
-int
-lsquic_mini_conn_ietf_pre_promote(struct ietf_mini_conn *conn,
-                                  lsquic_time_t now);
-
 #endif


### PR DESCRIPTION
Handle 0-RTT packets to be passed up to the full connection using the standard code path.