### PR TITLE
Release 4.7.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2026-05-16
+    - 4.7.0
+    - [IMPROVEMENT, API] Refactor: drop mini-conn promotion shortcut.
+    - [IMPROVEMENT, API] Improve multiple incoming header set handling.
+    - Remove unused push promise support.  API stays unchanged for now.
+
 2026-05-02
     - 4.6.4
     - [IMPROVEMENT] Use EAGAIN for pending headers (follow up to 4.6.3)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = u'2023, LiteSpeed Technologies'
 author = u'LiteSpeed Technologies'
 
 # The short X.Y version
-version = u'4.6'
+version = u'4.7'
 # The full version, including alpha/beta/rc tags
-release = u'4.6.4'
+release = u'4.7.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -26,8 +26,8 @@ extern "C" {
 #endif
 
 #define LSQUIC_MAJOR_VERSION 4
-#define LSQUIC_MINOR_VERSION 6
-#define LSQUIC_PATCH_VERSION 4
+#define LSQUIC_MINOR_VERSION 7
+#define LSQUIC_PATCH_VERSION 0
 
 #define LSQUIC_QUOTE(x)     #x
 #define LSQUIC_SVAL(v)      LSQUIC_QUOTE(v)


### PR DESCRIPTION
- [IMPROVEMENT, API] Refactor: drop mini-conn promotion shortcut.
- [IMPROVEMENT, API] Improve multiple incoming header set handling.
- Remove unused push promise support.  API stays unchanged for now.