### PR TITLE
Release 4.7.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+2026-05-25
+    - 4.7.1
+    - [FIX] Content-length check in QPACK decoder handler.
+    - [FIX] HTTP/1.x module: stricter validation for field names and values.
+    - [FIX] Sample tools: fix recvmmsg receive batching (issue #434).
+    - [FIX] crypto object ownership on promotion failure.
+    - [IMPROVEMENT] Use ls-hpack v2.3.5.
+
 2026-05-16
     - 4.7.0
     - [IMPROVEMENT, API] Refactor: drop mini-conn promotion shortcut.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = u'LiteSpeed Technologies'
 # The short X.Y version
 version = u'4.7'
 # The full version, including alpha/beta/rc tags
-release = u'4.7.0'
+release = u'4.7.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #define LSQUIC_MAJOR_VERSION 4
 #define LSQUIC_MINOR_VERSION 7
-#define LSQUIC_PATCH_VERSION 0
+#define LSQUIC_PATCH_VERSION 1
 
 #define LSQUIC_QUOTE(x)     #x
 #define LSQUIC_SVAL(v)      LSQUIC_QUOTE(v)

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -97,6 +97,7 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
 
+
 /* IMPORTANT: Keep values of IFC_SERVER and IFC_HTTP same as LSENG_SERVER
  * and LSENG_HTTP.
  */
@@ -1448,6 +1449,18 @@ typedef char mini_conn_does_not_have_more_cces[
     sizeof(((struct ietf_mini_conn *)0)->imc_cces)
     <= sizeof(((struct ietf_full_conn *)0)->ifc_cces) ? 1 : -1];
 
+
+/* Promotion failed: give ownership of crypto object back to mini conn. */
+static void
+give_enc_session_back_to_mini (struct lsquic_conn *mini_conn,
+                                                struct ietf_full_conn *conn)
+{
+    mini_conn->cn_enc_session = conn->ifc_conn.cn_enc_session;
+    conn->ifc_conn.cn_enc_session = NULL;
+    mini_conn->cn_esf_c->esf_set_conn(mini_conn->cn_enc_session, mini_conn);
+}
+
+
 struct lsquic_conn *
 lsquic_ietf_full_conn_server_new (struct lsquic_engine_public *enpub,
                unsigned flags, struct lsquic_conn *mini_conn)
@@ -1653,12 +1666,17 @@ lsquic_ietf_full_conn_server_new (struct lsquic_engine_public *enpub,
     return &conn->ifc_conn;
 
   err3:
+    assert(mini_conn->cn_enc_session == NULL);
+    give_enc_session_back_to_mini(mini_conn, conn);
     ietf_full_conn_ci_destroy(&conn->ifc_conn);
     return NULL;
 
   err2:
+    assert(mini_conn->cn_enc_session == NULL);
+    give_enc_session_back_to_mini(mini_conn, conn);
     lsquic_malo_destroy(conn->ifc_pub.packet_out_malo);
   err1:
+    assert(mini_conn->cn_enc_session != NULL);
     lsquic_send_ctl_cleanup(&conn->ifc_send_ctl);
     if (conn->ifc_pub.all_streams)
         lsquic_hash_destroy(conn->ifc_pub.all_streams);
@@ -9784,4 +9802,6 @@ lsquic_ietf_full_conn_test_push_disabled (unsigned results[5])
     free(conn.ifc_errmsg);
 }
 
+
 typedef char dcid_elem_fits_in_128_bytes[sizeof(struct dcid_elem) <= 128 ? 1 : - 1];
+

--- a/src/liblsquic/lsquic_http1x_if.c
+++ b/src/liblsquic/lsquic_http1x_if.c
@@ -64,6 +64,59 @@ struct header_writer_ctx
 /* flags for frames with request headers */
 #define HWC_REQUEST_HANDLING_FLAGS (HWC_SERVER|HWC_PUSH_PROMISE)
 
+
+/* Field name and value grammar: [RFC 9110] Sections 5.1 (Field Names),
+ * 5.5 (Field Values), and 5.6.2 (Tokens).
+ * Lowercase field names: [RFC 9113] Section 8.2 (HTTP Fields) and
+ * [RFC 9114] Section 4.1.2 (Malformed Requests and Responses).
+ */
+static const unsigned char is_tchar[0x100] =
+{
+    ['0'] = 1, ['1'] = 1, ['2'] = 1, ['3'] = 1, ['4'] = 1, ['5'] = 1,
+    ['6'] = 1, ['7'] = 1, ['8'] = 1, ['9'] = 1, ['a'] = 1, ['b'] = 1,
+    ['c'] = 1, ['d'] = 1, ['e'] = 1, ['f'] = 1, ['g'] = 1, ['h'] = 1,
+    ['i'] = 1, ['j'] = 1, ['k'] = 1, ['l'] = 1, ['m'] = 1, ['n'] = 1,
+    ['o'] = 1, ['p'] = 1, ['q'] = 1, ['r'] = 1, ['s'] = 1, ['t'] = 1,
+    ['u'] = 1, ['v'] = 1, ['w'] = 1, ['x'] = 1, ['y'] = 1, ['z'] = 1,
+    ['!'] = 1, ['#'] = 1, ['$'] = 1, ['%'] = 1, ['&'] = 1, ['\''] = 1,
+    ['*'] = 1, ['+'] = 1, ['-'] = 1, ['.'] = 1, ['^'] = 1, ['_'] = 1,
+    ['`'] = 1, ['|'] = 1, ['~'] = 1,
+};
+
+
+static int
+valid_field_name (const char *name, unsigned name_len)
+{
+    unsigned i;
+
+    if (name_len == 0)
+        return 0;
+
+    for (i = 0; i < name_len; ++i)
+        if (!is_tchar[(unsigned char) name[i]])
+            return 0;
+
+    return 1;
+}
+
+
+static int
+valid_field_value (const char *val, unsigned val_len)
+{
+    unsigned i;
+
+    for (i = 0; i < val_len; ++i)
+        if (!((unsigned char) val[i] == '\t' ||
+             ((unsigned char) val[i] >= 0x20 && (unsigned char) val[i] <= 0x7E) ||
+              (unsigned char) val[i] >= 0x80))
+        {
+            return 0;
+        }
+
+    return 1;
+}
+
+
 static void *
 h1h_create_header_set (void *ctx, lsquic_stream_t *stream, int is_push_promise)
 {
@@ -146,6 +199,13 @@ add_pseudo_header (struct header_writer_ctx *hwc, struct lsxpack_header *xhdr)
     val = lsxpack_header_get_value(xhdr);
     name_len = xhdr->name_len;
     val_len = xhdr->val_len;
+
+    if (!valid_field_value(val, val_len))
+    {
+        LSQ_INFO("pseudo-header `%.*s' contains invalid characters",
+            name_len, name);
+        return 1;
+    }
 
     switch (name_len)
     {
@@ -382,8 +442,6 @@ static int
 add_real_header (struct header_writer_ctx *hwc, struct lsxpack_header *xhdr)
 {
     int err;
-    unsigned i;
-    int n_upper;
     const char *name, *val;
     unsigned name_len, val_len;
 
@@ -399,6 +457,19 @@ add_real_header (struct header_writer_ctx *hwc, struct lsxpack_header *xhdr)
     name_len = xhdr->name_len;
     val_len = xhdr->val_len;
 
+    if (!valid_field_name(name, name_len))
+    {
+        LSQ_INFO("invalid header name `%.*s'", name_len, name);
+        return 1;
+    }
+
+    if (!valid_field_value(val, val_len))
+    {
+        LSQ_INFO("header `%.*s' contains invalid value characters",
+            name_len, name);
+        return 1;
+    }
+
     if (4 == name_len && 0 == memcmp(name, "host", 4))
     {
         if(hwc->pseh_mask & BIT(PSEH_AUTHORITY))
@@ -408,16 +479,6 @@ add_real_header (struct header_writer_ctx *hwc, struct lsxpack_header *xhdr)
         }
 
         hwc->hwc_flags |= HWC_SEEN_HOST;
-    }
-
-    n_upper = 0;
-    for (i = 0; i < name_len; ++i)
-        n_upper += isupper(name[i]);
-    if (n_upper > 0)
-    {
-        LSQ_INFO("Header name `%.*s' contains uppercase letters",
-            name_len, name);
-        return 1;
     }
 
     if (6 == name_len && memcmp(name, "cookie", 6) == 0)
@@ -453,6 +514,11 @@ add_header_to_uh (struct header_writer_ctx *hwc, struct lsxpack_header *xhdr)
     const char *name;
 
     name = lsxpack_header_get_name(xhdr);
+    if (xhdr->name_len == 0)
+    {
+        LSQ_INFO("empty header name");
+        return 1;
+    }
     LSQ_DEBUG("Got header '%.*s': '%.*s'", (int) xhdr->name_len, name,
                         (int) xhdr->val_len, lsxpack_header_get_value(xhdr));
     if (':' == name[0])

--- a/src/liblsquic/lsquic_qdec_hdl.c
+++ b/src/liblsquic/lsquic_qdec_hdl.c
@@ -509,7 +509,7 @@ is_content_length (const struct lsxpack_header *xhdr)
     return ((xhdr->flags & LSXPACK_QPACK_IDX)
                         && xhdr->qpack_index == LSQPACK_TNV_CONTENT_LENGTH_0)
         || (xhdr->name_len == 14 && 0 == memcmp(lsxpack_header_get_name(xhdr),
-                                                        "content-length", 13))
+                                                        "content-length", 14))
         ;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ SET(TESTS
     goaway_gquic_be
     hkdf
     hpi
+    http1x_if
     lsquic_hash
     mini_conn_delay
     packet_out

--- a/tests/test_http1x_if.c
+++ b/tests/test_http1x_if.c
@@ -65,8 +65,7 @@ add_request_pseudo_headers (void *hset)
 static void
 test_valid_request (void)
 {
-    static const char value[] = { 'a', 'l', 'p', 'h', 'a', '\t',
-                                                            (char) 0x80, };
+    static const char value[] = "alpha\t\x80";
     static const char expected[] =
         "GET / HTTP/1.1\r\n"
         "x-test: alpha\t\x80\r\n"
@@ -79,7 +78,7 @@ test_valid_request (void)
     hset = new_hset(1);
     assert(hset);
     add_request_pseudo_headers(hset);
-    assert(0 == process_header(hset, "x-test", 6, value, sizeof(value)));
+    assert(0 == process_header(hset, "x-test", 6, value, sizeof(value) - 1));
     assert(0 == process_header(hset, "cookie", 6, "a=b", 3));
     assert(0 == process_header(hset, "cookie", 6, "c=d", 3));
     assert(0 == lsquic_http1x_if->hsi_process_header(hset, NULL));

--- a/tests/test_http1x_if.c
+++ b/tests/test_http1x_if.c
@@ -1,0 +1,177 @@
+/* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "lsquic.h"
+#include "lsquic_headers.h"
+#include "lsquic_http1x_if.h"
+#include "lsxpack_header.h"
+
+
+struct test_xhdr
+{
+    struct lsxpack_header   xhdr;
+    char                    buf[0x100];
+};
+
+
+static void
+make_xhdr (struct test_xhdr *tx, const char *name, size_t name_len,
+                    const char *val, size_t val_len)
+{
+    assert(name_len + val_len <= sizeof(tx->buf));
+    memcpy(tx->buf, name, name_len);
+    memcpy(tx->buf + name_len, val, val_len);
+    lsxpack_header_set_offset2(&tx->xhdr, tx->buf, 0, name_len,
+                                                    name_len, val_len);
+}
+
+
+static int
+process_header (void *hset, const char *name, size_t name_len,
+                    const char *val, size_t val_len)
+{
+    struct test_xhdr tx;
+
+    make_xhdr(&tx, name, name_len, val, val_len);
+    return lsquic_http1x_if->hsi_process_header(hset, &tx.xhdr);
+}
+
+
+static void *
+new_hset (int is_server)
+{
+    struct http1x_ctor_ctx hcc = {
+        .conn           = NULL,
+        .max_headers_sz = MAX_HTTP1X_HEADERS_SIZE,
+        .is_server      = is_server,
+    };
+
+    return lsquic_http1x_if->hsi_create_header_set(&hcc, NULL, 0);
+}
+
+
+static void
+add_request_pseudo_headers (void *hset)
+{
+    assert(0 == process_header(hset, ":method", 7, "GET", 3));
+    assert(0 == process_header(hset, ":scheme", 7, "https", 5));
+    assert(0 == process_header(hset, ":path", 5, "/", 1));
+    assert(0 == process_header(hset, ":authority", 10, "example.com", 11));
+}
+
+
+static void
+test_valid_request (void)
+{
+    static const char value[] = { 'a', 'l', 'p', 'h', 'a', '\t',
+                                                            (char) 0x80, };
+    static const char expected[] =
+        "GET / HTTP/1.1\r\n"
+        "x-test: alpha\t\x80\r\n"
+        "Host: example.com\r\n"
+        "Cookie: a=b; c=d\r\n"
+        "\r\n";
+    void *hset;
+    const struct http1x_headers *h1h;
+
+    hset = new_hset(1);
+    assert(hset);
+    add_request_pseudo_headers(hset);
+    assert(0 == process_header(hset, "x-test", 6, value, sizeof(value)));
+    assert(0 == process_header(hset, "cookie", 6, "a=b", 3));
+    assert(0 == process_header(hset, "cookie", 6, "c=d", 3));
+    assert(0 == lsquic_http1x_if->hsi_process_header(hset, NULL));
+
+    h1h = hset;
+    assert(h1h->h1h_size == sizeof(expected) - 1);
+    assert(0 == memcmp(h1h->h1h_buf, expected, sizeof(expected) - 1));
+    lsquic_http1x_if->hsi_discard_header_set(hset);
+}
+
+
+static void
+test_bad_pseudo_value (const char *name, size_t name_len,
+                        const char *val, size_t val_len)
+{
+    void *hset;
+
+    hset = new_hset(1);
+    assert(hset);
+    assert(1 == process_header(hset, name, name_len, val, val_len));
+    lsquic_http1x_if->hsi_discard_header_set(hset);
+}
+
+
+static void
+test_bad_real_header (const char *name, size_t name_len,
+                        const char *val, size_t val_len)
+{
+    void *hset;
+
+    hset = new_hset(1);
+    assert(hset);
+    add_request_pseudo_headers(hset);
+    assert(1 == process_header(hset, name, name_len, val, val_len));
+    lsquic_http1x_if->hsi_discard_header_set(hset);
+}
+
+
+static void
+test_invalid_values (void)
+{
+    static const char method_cr[] = { 'G', 'E', '\r', 'T', };
+    static const char path_lf[] = { '/', '\n', 'x', };
+    static const char authority_nul[] = { 'e', 'x', '\0', 'a', };
+    static const char value_cr[] = { 'a', '\r', 'b', };
+    static const char value_lf[] = { 'a', '\n', 'b', };
+    static const char value_nul[] = { 'a', '\0', 'b', };
+    static const char cookie_lf[] = { 'a', '=', '\n', };
+
+    test_bad_pseudo_value(":method", 7, method_cr, sizeof(method_cr));
+    test_bad_pseudo_value(":path", 5, path_lf, sizeof(path_lf));
+    test_bad_pseudo_value(":authority", 10, authority_nul,
+                                                    sizeof(authority_nul));
+
+    test_bad_real_header("x-test", 6, value_cr, sizeof(value_cr));
+    test_bad_real_header("x-test", 6, value_lf, sizeof(value_lf));
+    test_bad_real_header("x-test", 6, value_nul, sizeof(value_nul));
+    test_bad_real_header("cookie", 6, cookie_lf, sizeof(cookie_lf));
+}
+
+
+static void
+test_invalid_names (void)
+{
+    test_bad_real_header("", 0, "v", 1);
+    test_bad_real_header("X-Test", 6, "v", 1);
+    test_bad_real_header("bad:name", 8, "v", 1);
+    test_bad_real_header("bad name", 8, "v", 1);
+    test_bad_real_header("bad@", 4, "v", 1);
+}
+
+
+static void
+test_bad_response_pseudo_value (void)
+{
+    static const char status_lf[] = { '2', '0', '0', '\n', };
+    void *hset;
+
+    hset = new_hset(0);
+    assert(hset);
+    assert(1 == process_header(hset, ":status", 7, status_lf,
+                                                    sizeof(status_lf)));
+    lsquic_http1x_if->hsi_discard_header_set(hset);
+}
+
+
+int
+main (void)
+{
+    test_valid_request();
+    test_invalid_values();
+    test_invalid_names();
+    test_bad_response_pseudo_value();
+    return 0;
+}


### PR DESCRIPTION
- [FIX] Content-length check in QPACK decoder handler.
- [FIX] HTTP/1.x module: stricter validation for field names and values.
- [FIX] Sample tools: fix recvmmsg receive batching (issue #434).
- [FIX] crypto object ownership on promotion failure.
- [IMPROVEMENT] Use ls-hpack v2.3.5.