### PR TITLE
Release 4.8.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+2026-06-15
+    - 4.8.0
+    - [API] Deprecate all gQUIC versions.
+    - [FIX] http1x: check size of Cookie: header.
+    - [FIX] Add checks to gQUIC client session resume code.
+    - [FIX] 32-bit parser bounds checks.
+    - [FIX] Use ls-qpack v2.6.3 to pick up a bunch of fixes.
+    - [DOCS] FAQ: example programs do work with google.com etc.
+
 2026-06-05
     - 4.7.2
     - [FIX] Only ignore Priority: header after PRIORITY_UPDATE and in

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -42,6 +42,7 @@ to the LiteSpeed QUIC and HTTP/3 Library:
     - Kirill Sabitov -- Bug fixes
     - Harold Newman -- Bug fixes
     - Richard Ramos -- Windows fixes
+    - youngseaz -- 32-bit transport param parser bug report
 
 Thank you!
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ and HTTP/3 functionality for servers and clients.  Most of the code in this
 distribution is used in our own products: LiteSpeed Web Server, LiteSpeed ADC,
 and OpenLiteSpeed.
 
-Currently supported QUIC versions are v1, v2, Internet-Draft versions 29, and 27;
-and the older "Google" QUIC versions Q043, Q046, an Q050.
+QUIC versions v1, v2, and Internet-Draft version 29 are enabled by default.
+Deprecated versions ID-27 and the older "Google" QUIC versions Q043, Q046,
+and Q050 are still supported, but are not enabled by default.
 
 Standard Compliance
 -------------------

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -28,23 +28,23 @@ has the form MAJOR.MINOR.PATCH, where
 QUIC Versions
 -------------
 
-LSQUIC supports two types of QUIC protocol: Google QUIC and IETF QUIC.  The
-former will at some point become obsolete, while the latter is still being
-developed by the IETF.  Both types are included in a single enum:
+LSQUIC supports two types of QUIC protocol: Google QUIC and IETF QUIC.
+Google QUIC versions are deprecated and are not enabled by default.  Both
+types are included in a single enum:
 
 .. type:: enum lsquic_version
 
     .. member:: LSQVER_043
 
-        Google QUIC version Q043
+        Google QUIC version Q043; this version is deprecated.
 
     .. member:: LSQVER_046
 
-        Google QUIC version Q046
+        Google QUIC version Q046; this version is deprecated.
 
     .. member:: LSQVER_050
 
-        Google QUIC version Q050
+        Google QUIC version Q050; this version is deprecated.
 
     .. member:: LSQVER_ID27
 
@@ -54,14 +54,13 @@ developed by the IETF.  Both types are included in a single enum:
 
         IETF QUIC version ID 29
 
-    .. member:: LSQVER_ID34
-
-        IETF QUIC version ID 34
-
     .. member:: LSQVER_I001
 
-        IETF QUIC version 1.  (This version is disabled by default until
-        the QUIC RFC is released).
+        IETF QUIC version 1.
+
+    .. member:: LSQVER_I002
+
+        IETF QUIC version 2.
 
     .. member:: N_LSQVER
 
@@ -84,7 +83,8 @@ Experimental versions.
 
 .. macro:: LSQUIC_DEPRECATED_VERSIONS
 
-Deprecated versions.
+Deprecated versions.  Deprecated versions are supported, but they are not
+enabled by default.
 
 .. macro:: LSQUIC_GQUIC_HEADER_VERSIONS
 
@@ -491,7 +491,7 @@ settings structure:
        this number of times in a row without making progress (that is,
        reading, writing, or changing stream state), loop break will occur.
 
-       The defaut value is :macro:`LSQUIC_DF_PROGRESS_CHECK`.
+       The default value is :macro:`LSQUIC_DF_PROGRESS_CHECK`.
 
     .. member:: int             es_rw_once
 
@@ -631,7 +631,7 @@ settings structure:
        send PING frames in the absence of other activity.
 
        By default, the server does not send PINGs and the period is set to zero.
-       The client's defaut value is :macro:`LSQUIC_DF_PING_PERIOD`.
+       The client's default value is :macro:`LSQUIC_DF_PING_PERIOD`.
 
        IETF QUIC only.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = u'2023, LiteSpeed Technologies'
 author = u'LiteSpeed Technologies'
 
 # The short X.Y version
-version = u'4.7'
+version = u'4.8'
 # The full version, including alpha/beta/rc tags
-release = u'4.7.2'
+release = u'4.8.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -20,28 +20,9 @@ To aid development, there is a :macro:`LSQUIC_FORCED_TCID0_VERSIONS` that
 specifies the list of versions with 0-sized connections.  (If you, for
 example, want to turn them off.)
 
-Once gQUIC becomes deprecated in the future, there will remain no technical
-reason why a single engine instance could not be used both for client and
-server connections.  It will be just work.  For example, the single
+gQUIC versions are deprecated and disabled by default.  There remains no
+technical reason why a single engine instance could not be used both for
+client and server connections.  It is just work.  For example, the single
 engine settings :type:`lsquic_engine_settings` will have to be separated
 into client and server settings, as the two usually do need to have
 separate settings.
-
-Example Programs
-================
-
-*http_client does not work with www.google.com, www.facebook.com, etc.*
-
-Check the version.  By defaut, ``http_client`` will use the latest supported
-version (at the time of this writing, "h3-31"), while the server may be using
-an older version, such as "h3-29".  Adding ``-o version=h3-29`` to the
-command line may well solve your issue.
-
-There is an `outstanding bug`_ where lsquic client does not perform version
-negotiation correctly for HTTP/3.  We do not expect this to be fixed, because
-a) this version negotiation mechanism is likely to become defunct when QUIC v1
-is released and b) version negotiation is not necessary for an HTTP/3 client,
-because the other side's version is communicated to it via the ``Alt-Svc`` HTTP
-header.
-
-.. _`outstanding bug`: https://github.com/litespeedtech/lsquic/issues/180

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,8 +16,9 @@ Most of the code in this distribution has been  used in our own products
 -- `LiteSpeed Web Server`_, `LiteSpeed Web ADC`_, and OpenLiteSpeed_ --
 since 2017.
 
-Currently supported QUIC versions are v1, Internet-Draft versions 29, and 27;
-and the older "Google" QUIC versions Q043, Q046, an Q050.
+QUIC versions v1, v2, and Internet-Draft version 29 are enabled by default.
+Deprecated versions ID-27 and the older "Google" QUIC versions Q043, Q046,
+and Q050 are still supported, but are not enabled by default.
 
 LSQUIC is licensed under the `MIT License`_; see LICENSE in the source
 distribution for details.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -832,14 +832,15 @@ QUIC versions in LSQUIC are gathered in an enum, :type:`lsquic_version`, and hav
 
   enum lsquic_version {
       LSQVER_043, LSQVER_046, LSQVER_050,     /* Google QUIC */
-      LSQVER_ID27, LSQVER_ID28, LSQVER_ID29,  /* IETF QUIC */
+      LSQVER_ID27, LSQVER_ID29,               /* IETF QUIC drafts */
+      LSQVER_I001, LSQVER_I002,               /* IETF QUIC RFC versions */
       /* ...some special entries skipped */
       N_LSQVER    /* <====================== Special value */
   };
 
 The special value "N_LSQVER" is used to let the engine pick the QUIC version.
-It picks the latest non-experimental version, so in this case it picks ID-29.
-(Experimental from the point of view of the library.)
+It picks the latest version that is neither deprecated nor experimental.
+(Deprecated and experimental from the point of view of the library.)
 
 Because version enum values are small -- and that is by design -- a list of
 versions can be passed around as bitmasks.
@@ -847,7 +848,7 @@ versions can be passed around as bitmasks.
 ::
 
   /* This allows list of versions to be specified as bitmask: */
-  es_versions = (1 << LSQVER_ID28) | (1 << LSQVER_ID29);
+  es_versions = (1 << LSQVER_I001) | (1 << LSQVER_I002);
 
 This is done, for example, when
 specifying list of versions to enable in engine settings using :member:`lsquic_engine_api.ea_versions`.
@@ -932,7 +933,7 @@ is parsed to see which setting to alter.
 
   while (/* getopt */)
   {
-      case 'o':   /* For example: -o version=h3-27 -o cc_algo=2 */
+      case 'o':   /* For example: -o version=h3 -o cc_algo=2 */
         if (!settings_initialized) {
           lsquic_engine_init_settings(&settings,
                           cert_file || key_file ? LSENG_SERVER : 0);

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -26,8 +26,8 @@ extern "C" {
 #endif
 
 #define LSQUIC_MAJOR_VERSION 4
-#define LSQUIC_MINOR_VERSION 7
-#define LSQUIC_PATCH_VERSION 2
+#define LSQUIC_MINOR_VERSION 8
+#define LSQUIC_PATCH_VERSION 0
 
 #define LSQUIC_QUOTE(x)     #x
 #define LSQUIC_SVAL(v)      LSQUIC_QUOTE(v)
@@ -107,8 +107,9 @@ enum lsquic_version
 };
 
 /**
- * We currently support versions 43, 46, 50, Draft-27, Draft-29,
- * and IETF QUIC v1.
+ * We currently support Google QUIC versions Q043, Q046, and Q050,
+ * IETF QUIC Draft-27 and Draft-29, and IETF QUIC v1 and v2.
+ * Deprecated and experimental versions are not enabled by default.
  * @see lsquic_version
  */
 #define LSQUIC_SUPPORTED_VERSIONS ((1 << N_LSQVER) - 1)
@@ -121,7 +122,8 @@ enum lsquic_version
 #define LSQUIC_EXPERIMENTAL_VERSIONS ( \
                             (1 << LSQVER_RESVED))
 
-#define LSQUIC_DEPRECATED_VERSIONS ((1 << LSQVER_ID27))
+#define LSQUIC_DEPRECATED_VERSIONS ((1 << LSQVER_043) | (1 << LSQVER_046) | \
+                                    (1 << LSQVER_050) | (1 << LSQVER_ID27))
 
 #define LSQUIC_GQUIC_HEADER_VERSIONS (1 << LSQVER_043)
 
@@ -670,7 +672,7 @@ struct lsquic_engine_settings {
      * this number of times in a row without making progress (that is,
      * reading, writing, or changing stream state), loop break will occur.
      *
-     * The defaut value is @ref LSQUIC_DF_PROGRESS_CHECK.
+     * The default value is @ref LSQUIC_DF_PROGRESS_CHECK.
      */
     unsigned        es_progress_check;
 
@@ -864,7 +866,7 @@ struct lsquic_engine_settings {
      * send PING frames in the absence of other activity.
      *
      * By default, the server does not send PINGs and the period is set to zero.
-     * The client's defaut value is @ref LSQUIC_DF_PING_PERIOD.
+     * The client's default value is @ref LSQUIC_DF_PING_PERIOD.
      */
     unsigned        es_ping_period;
 

--- a/src/liblsquic/lsquic_handshake.c
+++ b/src/liblsquic/lsquic_handshake.c
@@ -329,6 +329,8 @@ enum hsk_failure_reason
 lsquic_verify_stk (enc_session_t *,
                const struct sockaddr *ip_addr, uint64_t tm, lsquic_str_t *stk);
 
+#endif
+#if defined(NDEBUG) && !LSQUIC_TEST
 static
 #endif
 void lsquic_gen_stk(lsquic_server_config_t *, const struct sockaddr *, uint64_t tm,
@@ -609,7 +611,8 @@ lsquic_enc_session_serialize_sess_resume(struct lsquic_sess_resume_storage *stor
 
 
 #define CHECK_SPACE(need, start, end) \
-    do { if ((intptr_t) (need) > ((intptr_t) (end) - (intptr_t) (start))) \
+    do { if ((uint64_t) (need) > (uint64_t) ((const unsigned char *) (end) \
+                                - (const unsigned char *) (start))) \
         { return RTT_DESERIALIZE_BAD_CERT_SIZE; } \
     } while (0) \
 
@@ -630,11 +633,19 @@ lsquic_enc_session_deserialize_sess_resume(
     /*
      * check versions
      */
+    if (storage_size < sizeof(*storage))
+        return RTT_DESERIALIZE_BAD_CERT_SIZE;
     ver = lsquic_tag2ver(storage->quic_version_tag);
     if ((int)ver == -1 || !((1 << ver) & settings->es_versions))
         return RTT_DESERIALIZE_BAD_QUIC_VER;
     if (storage->serializer_version != RTT_SERIALIZER_VERSION)
         return RTT_DESERIALIZE_BAD_SERIAL_VER;
+    if (storage->sstk_len > sizeof(storage->sstk)
+        || storage->scfg_len > sizeof(storage->scfg)
+        || storage->cert_count >
+                ((uint8_t *) storage_end - (uint8_t *) (storage + 1))
+                                                    / sizeof(uint32_t))
+        return RTT_DESERIALIZE_BAD_CERT_SIZE;
     /*
      * server config
      */
@@ -2882,7 +2893,7 @@ lsquic_enc_session_handle_chlo_reply (enc_session_t *enc_session_p,
  *  then stk first 48 byte will be encrypted with AES128-GCM
  *  when encrypting, the salt is the last 12 bytes
  */
-#ifdef NDEBUG
+#if defined(NDEBUG) && !LSQUIC_TEST
 static
 #endif
 void
@@ -2890,7 +2901,7 @@ lsquic_gen_stk (lsquic_server_config_t *server_config, const struct sockaddr *ip
          uint64_t tm, unsigned char stk_out[STK_LENGTH])
 {
     unsigned char stk[STK_LENGTH + 16];
-    size_t out_len = STK_LENGTH + 16;
+    size_t out_len = STK_LENGTH - 12;
 
     memset(stk, 0 , 24);
     if (AF_INET == ip_addr->sa_family)

--- a/src/liblsquic/lsquic_hash.c
+++ b/src/liblsquic/lsquic_hash.c
@@ -79,8 +79,8 @@ lsquic_hash_create_ext (int (*cmp)(const void *, const void *, size_t),
     hash->qh_nbits     = nbits;
     hash->qh_iter_next = NULL;
     hash->qh_count     = 0;
-    hash->qh_hash_seed = get_seed() ^ (uint64_t)hash
-                        ^ ((uint64_t)buckets << 32) ^ rand();
+    hash->qh_hash_seed = get_seed() ^ (uint64_t) (uintptr_t) hash
+                        ^ ((uint64_t) (uintptr_t) buckets << 32) ^ rand();
     return hash;
 }
 

--- a/src/liblsquic/lsquic_http1x_if.c
+++ b/src/liblsquic/lsquic_http1x_if.c
@@ -1,6 +1,7 @@
 /* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
 #include <assert.h>
 #include <ctype.h>
+#include <limits.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
@@ -409,10 +410,31 @@ static int
 save_cookie (struct header_writer_ctx *hwc, const char *val, unsigned val_len)
 {
     char *cookie_val;
+    unsigned cookie_sz;
+
+    if (0 == hwc->cookie_sz)
+        cookie_sz = val_len;
+    else if (hwc->cookie_sz > UINT_MAX - 2
+                                    || val_len > UINT_MAX - hwc->cookie_sz - 2)
+    {
+        LSQ_INFO("headers too large");
+        return 1;
+    }
+    else
+        cookie_sz = hwc->cookie_sz + val_len + 2 /* "; " */;
+
+    if (hwc->max_headers_sz
+        && (size_t) hwc->w_off + 8 /* "Cookie: " */ + cookie_sz
+                                                + 2 /* "\r\n" */
+                                                > hwc->max_headers_sz)
+    {
+        LSQ_INFO("headers too large");
+        return 1;
+    }
 
     if (0 == hwc->cookie_sz)
     {
-        hwc->cookie_nalloc = hwc->cookie_sz = val_len;
+        hwc->cookie_nalloc = hwc->cookie_sz = cookie_sz;
         cookie_val = malloc(hwc->cookie_nalloc);
         if (!cookie_val)
             return -1;
@@ -421,10 +443,13 @@ save_cookie (struct header_writer_ctx *hwc, const char *val, unsigned val_len)
     }
     else
     {
-        hwc->cookie_sz += val_len + 2 /* "; " */;
+        hwc->cookie_sz = cookie_sz;
         if (hwc->cookie_sz > hwc->cookie_nalloc)
         {
-            hwc->cookie_nalloc = hwc->cookie_nalloc * 2 + val_len + 2;
+            if (hwc->cookie_nalloc > (UINT_MAX - val_len - 2) / 2)
+                hwc->cookie_nalloc = hwc->cookie_sz;
+            else
+                hwc->cookie_nalloc = hwc->cookie_nalloc * 2 + val_len + 2;
             cookie_val = realloc(hwc->cookie_val, hwc->cookie_nalloc);
             if (!cookie_val)
                 return -1;

--- a/src/liblsquic/lsquic_parse_Q050.c
+++ b/src/liblsquic/lsquic_parse_Q050.c
@@ -58,6 +58,7 @@ lsquic_Q050_parse_packet_in_long_begin (struct lsquic_packet_in *packet_in,
     int verneg, r;
     unsigned char first_byte;
     uint64_t payload_len, token_len;
+    size_t nread;
 
     if (length < 6)
         return -1;
@@ -130,7 +131,7 @@ lsquic_Q050_parse_packet_in_long_begin (struct lsquic_packet_in *packet_in,
             if (token_len >=
                         1ull << (sizeof(packet_in->pi_token_size) * 8))
                 return -1;
-            if (p + token_len > end)
+            if (token_len > (uint64_t) (end - p))
                 return -1;
             packet_in->pi_token = p - packet_in->pi_data;
             packet_in->pi_token_size = token_len;
@@ -145,9 +146,10 @@ lsquic_Q050_parse_packet_in_long_begin (struct lsquic_packet_in *packet_in,
         if (r < 0)
             return -1;
         p += r;
-        if (p - packet_in->pi_data + payload_len > length)
+        nread = p - packet_in->pi_data;
+        if (payload_len > (uint64_t) (length - nread))
             return -1;
-        length = p - packet_in->pi_data + payload_len;
+        length = nread + (size_t) payload_len;
         if (end - p < 4)
             return -1;
         state->pps_p      = p - r;

--- a/src/liblsquic/lsquic_parse_common.h
+++ b/src/liblsquic/lsquic_parse_common.h
@@ -6,6 +6,9 @@
 #ifndef LSQUIC_PARSE_COMMON_H
 #define LSQUIC_PARSE_COMMON_H 1
 
+#include <limits.h>
+#include <stdint.h>
+
 #ifdef WIN32
 #include "vc_compat.h"
 #endif
@@ -91,8 +94,8 @@ lsquic_is_valid_ietf_v1_or_Q046plus_hs_packet (const unsigned char *buf,
  * of bytes needed.
  */
 #define CHECK_STREAM_SPACE(need, pstart, pend) do {                 \
-    if ((intptr_t) (need) > ((pend) - (pstart))) {                  \
-        return -((int) (need));                                     \
+    if ((uint64_t) (need) > (uint64_t) ((pend) - (pstart))) {       \
+        return (uint64_t) (need) > INT_MAX ? -1 : -((int) (need));  \
     }                                                               \
 } while (0)
 

--- a/src/liblsquic/lsquic_parse_gquic_be.c
+++ b/src/liblsquic/lsquic_parse_gquic_be.c
@@ -40,7 +40,6 @@
 #define LSQUIC_LOGGER_MODULE LSQLM_PARSE
 #include "lsquic_logger.h"
 
-
 /* read 16 bits(2 bytes) time, unit: us */
 uint64_t
 lsquic_gquic_be_read_float_time16 (const void *mem)

--- a/src/liblsquic/lsquic_parse_gquic_be.h
+++ b/src/liblsquic/lsquic_parse_gquic_be.h
@@ -2,6 +2,8 @@
 #ifndef LSQUIC_PARSE_GQUIC_BE_H
 #define LSQUIC_PARSE_GQUIC_BE_H
 
+#include <stdint.h>
+
 /* Header file to make it easy to reference gQUIC parsing functions.  This
  * is only meant to be used internally.  The alternative would be to place
  * all gQUIC-big-endian functions -- from all versions -- in a single file,
@@ -9,7 +11,7 @@
  */
 
 #define CHECK_SPACE(need, pstart, pend)  \
-    do { if ((intptr_t) (need) > ((pend) - (pstart))) { return -1; } } while (0)
+    do { if ((uint64_t) (need) > (uint64_t) ((pend) - (pstart))) { return -1; } } while (0)
 
 uint64_t
 lsquic_gquic_be_read_float_time16 (const void *mem);

--- a/src/liblsquic/lsquic_parse_gquic_common.c
+++ b/src/liblsquic/lsquic_parse_gquic_common.c
@@ -30,7 +30,7 @@
 #include "lsquic_logger.h"
 
 #define CHECK_SPACE(need, pstart, pend)  \
-    do { if ((intptr_t) (need) > ((pend) - (pstart))) { return -1; } } while (0)
+    do { if ((uint64_t) (need) > (uint64_t) ((pend) - (pstart))) { return -1; } } while (0)
 
 /* This partially parses `packet_in' and returns 0 if in case it succeeded and
  * -1 on failure.

--- a/src/liblsquic/lsquic_parse_ietf_v1.c
+++ b/src/liblsquic/lsquic_parse_ietf_v1.c
@@ -44,7 +44,7 @@
 #include "lsquic_logger.h"
 
 #define CHECK_SPACE(need, pstart, pend)  \
-    do { if ((intptr_t) (need) > ((pend) - (pstart))) { return -1; } } while (0)
+    do { if ((uint64_t) (need) > (uint64_t) ((pend) - (pstart))) { return -1; } } while (0)
 
 #define FRAME_TYPE_ACK_FREQUENCY    0xAF
 #define FRAME_TYPE_TIMESTAMP        0x2F5
@@ -856,7 +856,7 @@ ietf_v1_parse_new_token_frame (const unsigned char *buf, size_t buf_len,
         return r;
     p += r;
 
-    if (p + token_size > end)
+    if (token_size > (uint64_t) (end - p))
         return -1;
     *token = p;
     p += token_size;
@@ -1754,6 +1754,7 @@ lsquic_ietf_v1_parse_packet_in_long_begin (struct lsquic_packet_in *packet_in,
     int r;
     unsigned char first_byte;
     uint64_t payload_len, token_len;
+    size_t nread;
 
     if (length < 6)
         return -1;
@@ -1833,7 +1834,7 @@ lsquic_ietf_v1_parse_packet_in_long_begin (struct lsquic_packet_in *packet_in,
             if (token_len >=
                         1ull << (sizeof(packet_in->pi_token_size) * 8))
                 return -1;
-            if (p + token_len > end)
+            if (token_len > (uint64_t) (end - p))
                 return -1;
             packet_in->pi_token = p - packet_in->pi_data;
             packet_in->pi_token_size = token_len;
@@ -1848,9 +1849,10 @@ lsquic_ietf_v1_parse_packet_in_long_begin (struct lsquic_packet_in *packet_in,
         if (r < 0)
             return -1;
         p += r;
-        if (p - packet_in->pi_data + payload_len > length)
+        nread = p - packet_in->pi_data;
+        if (payload_len > (uint64_t) (length - nread))
             return -1;
-        length = p - packet_in->pi_data + payload_len;
+        length = nread + (size_t) payload_len;
         if (end - p < 4)
             return -1;
         state->pps_p      = p - r;
@@ -1920,6 +1922,7 @@ lsquic_is_valid_ietf_v1_or_Q046plus_hs_packet (const unsigned char *buf,
     int r;
     unsigned char first_byte;
     uint64_t payload_len, token_len, packet_len;
+    size_t nread;
 
     if (length < 6)
         return 0;
@@ -1982,6 +1985,8 @@ lsquic_is_valid_ietf_v1_or_Q046plus_hs_packet (const unsigned char *buf,
         if (r < 0)
             return 0;
         p += r;
+        if (token_len > (uint64_t) (end - p))
+            return 0;
         p += token_len;
         if (p >= end)
             return 0;
@@ -1989,7 +1994,8 @@ lsquic_is_valid_ietf_v1_or_Q046plus_hs_packet (const unsigned char *buf,
         if (r < 0)
             return 0;
         p += r;
-        if (p - buf + payload_len > length)
+        nread = p - buf;
+        if (payload_len > (uint64_t) (length - nread))
             return 0;
         if (end - p < 4)
             return 0;

--- a/src/liblsquic/lsquic_rechist.c
+++ b/src/liblsquic/lsquic_rechist.c
@@ -236,7 +236,7 @@ rechist_test_sanity (const struct lsquic_rechist *rechist)
 {
     const struct rechist_elem *el;
     ptrdiff_t idx;
-    uint64_t *masks;
+    uintptr_t *masks;
     unsigned n_elems;
 
     masks = calloc(rechist->rh_n_masks, sizeof(masks[0]));
@@ -250,9 +250,9 @@ rechist_test_sanity (const struct lsquic_rechist *rechist)
             ++n_elems;
             idx = el - rechist->rh_elems;
             if (n_elems > rechist->rh_n_alloced
-                || idx >=  rechist->rh_n_alloced)
+                || idx < 0 || (unsigned) idx >= rechist->rh_n_alloced)
                 break;
-            masks[idx >> LOG2_BITS] |= 1ull << (idx & ((1u << LOG2_BITS) - 1));
+            masks[idx >> LOG2_BITS] |= (uintptr_t) 1 << (idx & ((1u << LOG2_BITS) - 1));
             if (el->re_next != UINT_MAX)
                 el = &rechist->rh_elems[el->re_next];
             else

--- a/src/liblsquic/lsquic_trans_params.c
+++ b/src/liblsquic/lsquic_trans_params.c
@@ -535,7 +535,7 @@ lsquic_tp_decode (const unsigned char *const buf, size_t bufsz,
         if (s < 0)
             return -1;
         p += s;
-        if ((ptrdiff_t) len > end - p)
+        if (len > (uint64_t) (end - p))
             return -1;
         tpi = tpi_val_2_enum(param_id);
         if (tpi <= LAST_TPI)
@@ -1125,7 +1125,7 @@ lsquic_tp_decode_27 (const unsigned char *const buf, size_t bufsz,
         if (s < 0)
             return -1;
         p += s;
-        if ((ptrdiff_t) len > end - p)
+        if (len > (uint64_t) (end - p))
             return -1;
         tpi = tpi_val_2_enum(param_id);
         if (tpi <= LAST_TPI)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,7 +30,6 @@ SET(TESTS
     arr
     attq
     blocked_gquic_be
-    bounds_helpers
     bw_sampler
     conn_close_gquic_be
     crypto_gen
@@ -86,6 +85,7 @@ IF (CMAKE_SYSTEM_NAME STREQUAL "Linux")
 ENDIF()
 
 IF (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    SET(TESTS ${TESTS} bounds_helpers)
     # No regexes on Windows
     SET(TESTS ${TESTS} ack_merge)
     # No open_memstream() on Windows

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ SET(TESTS
     arr
     attq
     blocked_gquic_be
+    bounds_helpers
     bw_sampler
     conn_close_gquic_be
     crypto_gen
@@ -63,11 +64,13 @@ SET(TESTS
     send_headers
     send_ctl_bw_lifecycle
     senhist
+    sess_resume
     set
     sfcw
     shi
     spi
     stop_waiting_gquic_be
+    stk
     streamgen
     streamparse
     tokgen

--- a/tests/test_bounds_helpers.c
+++ b/tests/test_bounds_helpers.c
@@ -1,0 +1,148 @@
+/* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/queue.h>
+
+#include <openssl/ssl.h>
+
+#include "lsquic.h"
+#include "lsquic_types.h"
+#include "lsquic_int_types.h"
+#include "lsquic_version.h"
+#include "lsquic_packet_common.h"
+#include "lsquic_packet_in.h"
+#include "lsquic_parse.h"
+#include "lsquic_parse_common.h"
+#include "lsquic_parse_gquic_be.h"
+#include "lsquic_hash.h"
+#include "lsquic_mm.h"
+#include "lsquic_conn.h"
+#include "lsquic_enc_sess.h"
+#include "lsquic_engine_public.h"
+#include "lsquic_handshake.h"
+
+#define TEST_MAX_SCFG_LENGTH 512
+#define TEST_MAX_SPUBS_LENGTH 32
+#define TEST_RTT_SERIALIZER_VERSION (1 << 0)
+
+struct test_sess_resume_storage
+{
+    uint32_t    quic_version_tag;
+    uint32_t    serializer_version;
+    uint32_t    ver;
+    uint32_t    aead;
+    uint32_t    kexs;
+    uint32_t    pdmd;
+    uint64_t    orbt;
+    uint64_t    expy;
+    uint64_t    sstk_len;
+    uint64_t    scfg_len;
+    uint64_t    scfg_flag;
+    uint8_t     sstk[STK_LENGTH];
+    uint8_t     scfg[TEST_MAX_SCFG_LENGTH];
+    uint8_t     sscid[SCID_LENGTH];
+    uint8_t     spubs[TEST_MAX_SPUBS_LENGTH];
+    uint32_t    cert_count;
+};
+
+
+static int
+test_check_stream_space (uint64_t need)
+{
+    const unsigned char buf[1] = { 0, };
+
+    CHECK_STREAM_SPACE(need, buf, buf + sizeof(buf));
+    return 0;
+}
+
+
+static void
+test_gquic_common_check_space (void)
+{
+    unsigned char buf[] = { PACKET_PUBLIC_FLAGS_8BYTE_CONNECTION_ID, };
+    lsquic_packet_in_t packet_in;
+    struct packin_parse_state ppstate;
+    int s;
+
+    memset(&packet_in, 0, sizeof(packet_in));
+    packet_in.pi_data = buf;
+
+    s = lsquic_gquic_parse_packet_in_begin(&packet_in, sizeof(buf), 1,
+                                                            0, &ppstate);
+    assert(s < 0);
+}
+
+
+static void
+test_gquic_be_check_space (void)
+{
+    unsigned char buf[] =
+    {
+        0xA0,       /* STREAM frame with 1-byte stream ID and 2-byte length */
+        0x01,       /* Stream ID */
+        0x00, 0x02, /* Declared data length, with no data following */
+    };
+    stream_frame_t stream_frame;
+    int s;
+
+    s = lsquic_gquic_be_parse_stream_frame(buf, sizeof(buf), &stream_frame);
+    assert(s < 0);
+}
+
+
+static void
+test_check_stream_space_macro (void)
+{
+    assert(0 == test_check_stream_space(1));
+    assert(test_check_stream_space(0x80000000ULL) < 0);
+}
+
+
+static void
+test_handshake_sess_resume_check_space (void)
+{
+    struct
+    {
+        struct test_sess_resume_storage storage;
+        uint32_t cert_len;
+    } test_storage;
+    struct lsquic_engine_public enpub;
+    struct lsquic_conn lconn;
+    enc_session_t *enc_sess;
+    lsquic_cid_t cid;
+
+    memset(&test_storage, 0, sizeof(test_storage));
+    test_storage.storage.quic_version_tag = lsquic_ver2tag(LSQVER_043);
+    test_storage.storage.serializer_version = TEST_RTT_SERIALIZER_VERSION;
+    test_storage.storage.cert_count = 1;
+    test_storage.cert_len = 0x80000000u;
+
+    memset(&enpub, 0, sizeof(enpub));
+    lsquic_engine_init_settings(&enpub.enp_settings, 0);
+    enpub.enp_settings.es_versions = 1 << LSQVER_043;
+
+    memset(&cid, 0, sizeof(cid));
+    cid.len = GQUIC_CID_LEN;
+    memset(&lconn, 0, sizeof(lconn));
+    lconn.cn_version = LSQVER_043;
+
+    enc_sess = lsquic_enc_session_gquic_gquic_1.esf_create_client(&lconn,
+        "example.com", cid, &enpub, (const unsigned char *) &test_storage,
+        sizeof(test_storage));
+    assert(enc_sess);
+    assert(0 == lsquic_enc_session_common_gquic_1.
+                                esf_is_sess_resume_enabled(enc_sess));
+    lsquic_enc_session_gquic_gquic_1.esf_destroy(enc_sess);
+}
+
+
+int
+main (void)
+{
+    test_gquic_common_check_space();
+    test_gquic_be_check_space();
+    test_check_stream_space_macro();
+    test_handshake_sess_resume_check_space();
+    return 0;
+}

--- a/tests/test_h3_framing.c
+++ b/tests/test_h3_framing.c
@@ -398,7 +398,7 @@ init_test_objs (struct test_objs *tobjs, unsigned initial_conn_window,
     tobjs->eng_pub.enp_hsi_if = &tobjs->hsi_if;
     lsquic_send_ctl_init(&tobjs->send_ctl, &tobjs->alset, &tobjs->eng_pub,
         &tobjs->ver_neg, &tobjs->conn_pub, 0);
-    tobjs->send_ctl.sc_adaptive_cc.acc_cubic.cu_cwnd = ~0ull;
+    tobjs->send_ctl.sc_adaptive_cc.acc_cubic.cu_cwnd = ~0UL;
     tobjs->send_ctl.sc_cong_ctl = &tobjs->send_ctl.sc_adaptive_cc.acc_cubic;
     tobjs->stream_if = &stream_if;
     tobjs->stream_if_ctx = &test_ctx;

--- a/tests/test_http1x_if.c
+++ b/tests/test_http1x_if.c
@@ -1,5 +1,4 @@
 /* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
-/* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
 #include <assert.h>
 #include <stddef.h>
 #include <string.h>
@@ -41,15 +40,22 @@ process_header (void *hset, const char *name, size_t name_len,
 
 
 static void *
-new_hset (int is_server)
+new_hset_with_limit (int is_server, unsigned max_headers_sz)
 {
     struct http1x_ctor_ctx hcc = {
         .conn           = NULL,
-        .max_headers_sz = MAX_HTTP1X_HEADERS_SIZE,
+        .max_headers_sz = max_headers_sz,
         .is_server      = is_server,
     };
 
     return lsquic_http1x_if->hsi_create_header_set(&hcc, NULL, 0);
+}
+
+
+static void *
+new_hset (int is_server)
+{
+    return new_hset_with_limit(is_server, MAX_HTTP1X_HEADERS_SIZE);
 }
 
 
@@ -87,6 +93,20 @@ test_valid_request (void)
     h1h = hset;
     assert(h1h->h1h_size == sizeof(expected) - 1);
     assert(0 == memcmp(h1h->h1h_buf, expected, sizeof(expected) - 1));
+    lsquic_http1x_if->hsi_discard_header_set(hset);
+}
+
+
+static void
+test_cookie_size_limit (void)
+{
+    void *hset;
+
+    hset = new_hset_with_limit(1, 30);
+    assert(hset);
+    add_request_pseudo_headers(hset);
+    assert(0 == process_header(hset, "cookie", 6, "a=b", 3));
+    assert(1 == process_header(hset, "cookie", 6, "c=d", 3));
     lsquic_http1x_if->hsi_discard_header_set(hset);
 }
 
@@ -170,6 +190,7 @@ int
 main (void)
 {
     test_valid_request();
+    test_cookie_size_limit();
     test_invalid_values();
     test_invalid_names();
     test_bad_response_pseudo_value();

--- a/tests/test_min_heap.c
+++ b/tests/test_min_heap.c
@@ -44,7 +44,7 @@ test_min_heap (void)
 
     heap.mh_nelem = 0;
     for (i = 0; i < MAX_ELEMS; ++i)
-        lsquic_mh_insert(&heap, (void *) i, i);
+        lsquic_mh_insert(&heap, (void *) (uintptr_t) i, i);
     verify_min_heap(&heap);
 #ifdef _MSC_VER
     prev_val = 0;
@@ -59,7 +59,7 @@ test_min_heap (void)
 
     heap.mh_nelem = 0;
     for (i = MAX_ELEMS; i > 0; --i)
-        lsquic_mh_insert(&heap, (void *) i, i);
+        lsquic_mh_insert(&heap, (void *) (uintptr_t) i, i);
     verify_min_heap(&heap);
     for (i = 0; i < MAX_ELEMS; ++i)
     {

--- a/tests/test_packet_resize.c
+++ b/tests/test_packet_resize.c
@@ -262,7 +262,9 @@ my_gsf_read (void *stream, void *buf, size_t len, int *fin)
 
     while (p < end)
     {
-        n = MIN(end - p, cursor->data_sz - cursor->off);
+        n = end - p;
+        if (n > (size_t) (cursor->data_sz - cursor->off))
+            n = cursor->data_sz - cursor->off;
         memcpy(p, cursor->data + cursor->off, n);
         cursor->off += n;
         if (cursor->off == cursor->data_sz)

--- a/tests/test_parse_packet_in.c
+++ b/tests/test_parse_packet_in.c
@@ -16,7 +16,6 @@
 #include "lsquic_engine_public.h"
 #include "lsquic_version.h"
 
-
 struct parse_packet_in_test
 {
     int                 ppit_lineno;
@@ -497,6 +496,149 @@ run_ppi_test (struct lsquic_mm *mm, const struct parse_packet_in_test *ppit)
 }
 
 
+static void
+test_oversized_ietf_v1_lengths (void)
+{
+    static const unsigned char len_0x80000000[] =
+        { 0xC0, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, };
+    const struct parse_funcs *const pf = select_pf_by_ver(LSQVER_I001);
+    unsigned char buf[0x100];
+    struct stream_frame stream_frame;
+    const unsigned char *token;
+    lsquic_ver_tag_t tag;
+    size_t token_sz;
+    int s;
+
+    /* NEW_TOKEN frame with oversized token length. */
+    buf[0] = 0x07;
+    memcpy(buf + 1, len_0x80000000, sizeof(len_0x80000000));
+    s = pf->pf_parse_new_token_frame(buf, 1 + sizeof(len_0x80000000),
+                                                        &token, &token_sz);
+    assert(s < 0);
+
+    /* STREAM frame with oversized payload length. */
+    buf[0] = 0x0A;   /* STREAM frame with LEN bit set */
+    buf[1] = 0;      /* Stream ID */
+    memcpy(buf + 2, len_0x80000000, sizeof(len_0x80000000));
+    s = pf->pf_parse_stream_frame(buf, 2 + sizeof(len_0x80000000),
+                                                            &stream_frame);
+    assert(s < 0);
+
+    /* CRYPTO frame with oversized payload length. */
+    buf[0] = 0x06;
+    buf[1] = 0;      /* Offset */
+    memcpy(buf + 2, len_0x80000000, sizeof(len_0x80000000));
+    s = pf->pf_parse_crypto_frame(buf, 2 + sizeof(len_0x80000000),
+                                                            &stream_frame);
+    assert(s < 0);
+
+    /* Initial packet validation helper with oversized token length. */
+    memset(buf, 0, sizeof(buf));
+    buf[0] = 0xC0;   /* Long header, Initial */
+    buf[4] = 1;      /* Version: 1 */
+    buf[5] = 8;      /* DCID length */
+    memcpy(buf + 6, "\x01\x02\x03\x04\x05\x06\x07\x08", 8);
+    buf[14] = 0;     /* SCID length */
+    memcpy(buf + 15, len_0x80000000, sizeof(len_0x80000000));
+    s = lsquic_is_valid_ietf_v1_or_Q046plus_hs_packet(buf,
+                            15 + sizeof(len_0x80000000), &tag);
+    assert(0 == s);
+
+    /* Initial packet validation helper with oversized payload length. */
+    memset(buf, 0, sizeof(buf));
+    buf[0] = 0xC0;   /* Long header, Initial */
+    buf[4] = 1;      /* Version: 1 */
+    buf[5] = 8;      /* DCID length */
+    memcpy(buf + 6, "\x01\x02\x03\x04\x05\x06\x07\x08", 8);
+    buf[14] = 0;     /* SCID length */
+    buf[15] = 0;     /* Token length */
+    memcpy(buf + 16, len_0x80000000, sizeof(len_0x80000000));
+    s = lsquic_is_valid_ietf_v1_or_Q046plus_hs_packet(buf,
+                            16 + sizeof(len_0x80000000), &tag);
+    assert(0 == s);
+}
+
+
+static size_t
+make_initial_with_oversized_len (unsigned char *buf, enum lsquic_version version,
+                                                int oversized_token)
+{
+    static const unsigned char len_0x80000000[] =
+        { 0xC0, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, };
+    unsigned char *p = buf;
+    lsquic_ver_tag_t tag;
+
+    *p++ = 0xC0;     /* Long header, Initial */
+    tag = lsquic_ver2tag(version);
+    memcpy(p, &tag, sizeof(tag));
+    p += sizeof(tag);
+    *p++ = 8;        /* DCID length */
+    memcpy(p, "\x01\x02\x03\x04\x05\x06\x07\x08", 8);
+    p += 8;
+    *p++ = 0;        /* SCID length */
+    if (oversized_token == 2)
+        *p++ = 16;   /* Larger than remaining packet, below token size cap. */
+    else if (oversized_token)
+    {
+        memcpy(p, len_0x80000000, sizeof(len_0x80000000));
+        p += sizeof(len_0x80000000);
+    }
+    else
+    {
+        *p++ = 0;    /* Token length */
+        memcpy(p, len_0x80000000, sizeof(len_0x80000000));
+        p += sizeof(len_0x80000000);
+    }
+
+    return p - buf;
+}
+
+
+static void
+run_long_begin_test (struct lsquic_mm *mm, enum lsquic_version version,
+                                                int oversized_token)
+{
+    lsquic_packet_in_t *packet_in;
+    struct packin_parse_state ppstate;
+    size_t sz;
+    int s;
+
+    packet_in = lsquic_mm_get_packet_in(mm);
+    packet_in->pi_data = lsquic_mm_get_packet_in_buf(mm, 1370);
+    packet_in->pi_flags |= PI_OWN_DATA;
+    sz = make_initial_with_oversized_len(packet_in->pi_data, version,
+                                                            oversized_token);
+
+    if (version == LSQVER_050)
+        s = lsquic_Q050_parse_packet_in_long_begin(packet_in, sz, 1, 8,
+                                                                    &ppstate);
+    else
+        s = lsquic_ietf_v1_parse_packet_in_long_begin(packet_in, sz, 1, 8,
+                                                                    &ppstate);
+    assert(s < 0);
+
+    lsquic_mm_put_packet_in(mm, packet_in);
+}
+
+
+static int
+test_check_stream_space (uint64_t need)
+{
+    const unsigned char buf[1] = { 0, };
+
+    CHECK_STREAM_SPACE(need, buf, buf + sizeof(buf));
+    return 0;
+}
+
+
+static void
+test_space_check_helpers (void)
+{
+    assert(0 == test_check_stream_space(1));
+    assert(test_check_stream_space(0x80000000ULL) < 0);
+}
+
+
 int
 main (void)
 {
@@ -507,6 +649,15 @@ main (void)
 
     for (i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i)
         run_ppi_test(&mm, &tests[i]);
+
+    test_oversized_ietf_v1_lengths();
+    run_long_begin_test(&mm, LSQVER_I001, 1);
+    run_long_begin_test(&mm, LSQVER_I001, 2);
+    run_long_begin_test(&mm, LSQVER_I001, 0);
+    run_long_begin_test(&mm, LSQVER_050, 1);
+    run_long_begin_test(&mm, LSQVER_050, 2);
+    run_long_begin_test(&mm, LSQVER_050, 0);
+    test_space_check_helpers();
 
     lsquic_mm_cleanup(&mm);
     return 0;

--- a/tests/test_rechist.c
+++ b/tests/test_rechist.c
@@ -205,7 +205,7 @@ test6 (void)
 {
     lsquic_rechist_t rechist;
     char buf[256];
-    long int time = 12087061905875;
+    lsquic_time_t time = 12087061905875ULL;
     unsigned i;
 
     lsquic_rechist_init(&rechist, 0, 0);

--- a/tests/test_sess_resume.c
+++ b/tests/test_sess_resume.c
@@ -1,0 +1,112 @@
+/* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/queue.h>
+
+#include <openssl/aead.h>
+
+#include "lsquic_types.h"
+#include "lsquic.h"
+#include "lsquic_hash.h"
+#include "lsquic_int_types.h"
+#include "lsquic_conn.h"
+#include "lsquic_mm.h"
+#include "lsquic_version.h"
+#include "lsquic_enc_sess.h"
+#include "lsquic_engine_public.h"
+#include "lsquic_handshake.h"
+
+
+struct test_sess_resume_storage
+{
+    uint32_t    quic_version_tag;
+    uint32_t    serializer_version;
+    uint32_t    ver;
+    uint32_t    aead;
+    uint32_t    kexs;
+    uint32_t    pdmd;
+    uint64_t    orbt;
+    uint64_t    expy;
+    uint64_t    sstk_len;
+    uint64_t    scfg_len;
+    uint64_t    scfg_flag;
+    uint8_t     sstk[STK_LENGTH];
+    uint8_t     scfg[512];
+    uint8_t     sscid[SCID_LENGTH];
+    uint8_t     spubs[32];
+    uint32_t    cert_count;
+};
+
+
+extern struct enc_session_funcs_gquic lsquic_enc_session_gquic_gquic_1;
+extern struct enc_session_funcs_common lsquic_enc_session_common_gquic_1;
+
+
+static enc_session_t *
+create_client (const struct test_sess_resume_storage *storage,
+                                            size_t storage_sz)
+{
+    struct lsquic_engine_public enpub;
+    struct lsquic_conn lconn;
+    lsquic_cid_t cid;
+
+    memset(&enpub, 0, sizeof(enpub));
+    lsquic_engine_init_settings(&enpub.enp_settings, 0);
+    enpub.enp_settings.es_versions = 1 << LSQVER_046;
+    memset(&lconn, 0, sizeof(lconn));
+    lconn.cn_version = LSQVER_046;
+    memset(&cid, 0, sizeof(cid));
+
+    return lsquic_enc_session_gquic_gquic_1.esf_create_client(&lconn,
+                "example.com", cid, &enpub, (const unsigned char *) storage,
+                storage_sz);
+}
+
+
+static void
+init_storage (struct test_sess_resume_storage *storage)
+{
+    memset(storage, 0, sizeof(*storage));
+    storage->quic_version_tag = lsquic_ver2tag(LSQVER_046);
+    storage->serializer_version = 1;
+}
+
+
+static void
+test_bad_resume (const char *name, uint64_t sstk_len, uint64_t scfg_len,
+                                                    uint32_t cert_count)
+{
+    struct {
+        struct test_sess_resume_storage storage;
+        uint8_t trailer;
+    } buf;
+    enc_session_t *enc_session;
+
+    init_storage(&buf.storage);
+    buf.storage.sstk_len = sstk_len;
+    buf.storage.scfg_len = scfg_len;
+    buf.storage.cert_count = cert_count;
+
+    enc_session = create_client(&buf.storage, sizeof(buf.storage) + 1);
+    assert(enc_session);
+    if (lsquic_enc_session_common_gquic_1
+                                .esf_is_sess_resume_enabled(enc_session))
+    {
+        fprintf(stderr, "%s: malformed resume data was accepted\n", name);
+        assert(0);
+    }
+    lsquic_enc_session_gquic_gquic_1.esf_destroy(enc_session);
+}
+
+
+int
+main (void)
+{
+    test_bad_resume("oversized STK", STK_LENGTH + 1, 0, 0);
+    test_bad_resume("oversized SCFG", 0, 512 + 1, 0);
+    test_bad_resume("truncated cert chain", 0, 0, 2);
+
+    return 0;
+}

--- a/tests/test_stk.c
+++ b/tests/test_stk.c
@@ -1,0 +1,93 @@
+/* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/queue.h>
+
+#ifdef WIN32
+#include <ws2tcpip.h>
+#else
+#include <netinet/in.h>
+#endif
+
+#include <openssl/aead.h>
+#include <openssl/rand.h>
+
+#include "lsquic_hash.h"
+#include "lsquic_handshake.h"
+
+/*
+ * Exercise GQUIC source-address-token generation directly.  The token is
+ * exactly STK_LENGTH bytes: ciphertext plus tag in the first STK_LENGTH - 12
+ * bytes and the AEAD nonce in the final 12 bytes.  Verify that generation does
+ * not write past that fixed-size output buffer and that both IPv4 and IPv6
+ * tokens decrypt to the expected peer address and timestamp.
+ */
+void
+lsquic_gen_stk(lsquic_server_config_t *, const struct sockaddr *, uint64_t,
+               unsigned char[STK_LENGTH]);
+
+
+static void
+test_one_stk (const struct sockaddr *sa)
+{
+    lsquic_server_config_t server_config;
+    unsigned char key[16];
+    unsigned char plain[STK_LENGTH];
+    size_t plain_len;
+    uint64_t tm;
+    struct {
+        unsigned char stk[STK_LENGTH];
+        unsigned char canary[32];
+    } out;
+
+    memset(&server_config, 0, sizeof(server_config));
+    RAND_bytes(key, sizeof(key));
+    assert(1 == EVP_AEAD_CTX_init(&server_config.lsc_stk_ctx,
+                    EVP_aead_aes_128_gcm(), key, sizeof(key), 12, NULL));
+
+    tm = 123456789;
+    memset(&out, 0xA5, sizeof(out));
+    lsquic_gen_stk(&server_config, sa, tm, out.stk);
+    assert(0 == memcmp(out.canary,
+                "\xA5\xA5\xA5\xA5\xA5\xA5\xA5\xA5"
+                "\xA5\xA5\xA5\xA5\xA5\xA5\xA5\xA5"
+                "\xA5\xA5\xA5\xA5\xA5\xA5\xA5\xA5"
+                "\xA5\xA5\xA5\xA5\xA5\xA5\xA5\xA5",
+                sizeof(out.canary)));
+
+    plain_len = sizeof(plain);
+    assert(1 == EVP_AEAD_CTX_open(&server_config.lsc_stk_ctx, plain,
+                    &plain_len, sizeof(plain), out.stk + STK_LENGTH - 12,
+                    12, out.stk, STK_LENGTH - 12, NULL, 0));
+    assert(plain_len == STK_LENGTH - 24);
+    if (AF_INET == sa->sa_family)
+        assert(0 == memcmp(plain,
+                    &((const struct sockaddr_in *) sa)->sin_addr.s_addr, 4));
+    else
+        assert(0 == memcmp(plain,
+                    &((const struct sockaddr_in6 *) sa)->sin6_addr, 16));
+    assert(0 == memcmp(plain + 16, &tm, sizeof(tm)));
+
+    EVP_AEAD_CTX_cleanup(&server_config.lsc_stk_ctx);
+}
+
+
+int
+main (void)
+{
+    struct sockaddr_in in;
+    struct sockaddr_in6 in6;
+
+    memset(&in, 0, sizeof(in));
+    in.sin_family = AF_INET;
+    in.sin_addr.s_addr = htonl(0x7F000001);
+    test_one_stk((const struct sockaddr *) &in);
+
+    memset(&in6, 0, sizeof(in6));
+    in6.sin6_family = AF_INET6;
+    in6.sin6_addr.s6_addr[15] = 1;
+    test_one_stk((const struct sockaddr *) &in6);
+
+    return 0;
+}

--- a/tests/test_trapa.c
+++ b/tests/test_trapa.c
@@ -278,6 +278,23 @@ decode_file (const char *name)
 }
 
 
+static void
+test_oversized_param_len (void)
+{
+    static const unsigned char buf[] =
+    {
+        /* Unknown transport parameter ID: */
+        0x21,
+        /* Length: 0x80000000 */
+        0xC0, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00,
+    };
+    struct transport_params params;
+
+    assert(lsquic_tp_decode(buf, sizeof(buf), 0, &params) < 0);
+    assert(lsquic_tp_decode_27(buf, sizeof(buf), 0, &params) < 0);
+}
+
+
 int
 main (int argc, char **argv)
 {
@@ -302,6 +319,8 @@ main (int argc, char **argv)
 
     for (i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i)
         run_test(&tests[i]);
+
+    test_oversized_param_len();
 
     return 0;
 }


### PR DESCRIPTION
- [API] Deprecate all gQUIC versions.
- [FIX] http1x: check size of Cookie: header.
- [FIX] Add checks to gQUIC client session resume code.
- [FIX] 32-bit parser bounds checks.
- [FIX] Use ls-qpack v2.6.3 to pick up a bunch of fixes.
- [DOCS] FAQ: example programs do work with google.com etc.