### PR TITLE
Fix sc_bytes_scheduled underflow by caching the attributed packet size (po_acct_sz)

### DIFF
--- a/src/liblsquic/lsquic_packet_out.h
+++ b/src/liblsquic/lsquic_packet_out.h
@@ -138,6 +138,7 @@ typedef struct lsquic_packet_out
     unsigned short     po_data_sz;      /* Number of usable bytes in data */
     unsigned short     po_enc_data_sz;  /* Number of usable bytes in data */
     unsigned short     po_sent_sz;      /* If PO_SENT_SZ is set, real size of sent buffer. */
+    unsigned short     po_acct_sz;      /* Size added to sc_bytes_scheduled at schedule time. */
     /* TODO Revisit po_regen_sz once gQUIC is dropped.  Now that all frames
      * are recorded, we have more flexibility where to place ACK frames; they
      * no longer really have to be at the beginning of the packet, since we

--- a/src/liblsquic/lsquic_send_ctl.c
+++ b/src/liblsquic/lsquic_send_ctl.c
@@ -728,7 +728,8 @@ send_ctl_sched_Xpend_common (struct lsquic_send_ctl *ctl,
 {
     packet_out->po_flags |= PO_SCHED;
     ++ctl->sc_n_scheduled;
-    ctl->sc_bytes_scheduled += packet_out_total_sz(packet_out);
+    packet_out->po_acct_sz = packet_out_total_sz(packet_out);   /* cache; subtract same at remove */
+    ctl->sc_bytes_scheduled += packet_out->po_acct_sz;
     lsquic_send_ctl_sanity_check(ctl);
 }
 
@@ -759,7 +760,7 @@ send_ctl_sched_remove (struct lsquic_send_ctl *ctl,
     packet_out->po_flags &= ~PO_SCHED;
     assert(ctl->sc_n_scheduled);
     --ctl->sc_n_scheduled;
-    ctl->sc_bytes_scheduled -= packet_out_total_sz(packet_out);
+    ctl->sc_bytes_scheduled -= packet_out->po_acct_sz;
     lsquic_send_ctl_sanity_check(ctl);
 }
 
@@ -2097,7 +2098,7 @@ lsquic_send_ctl_do_sanity_check (const struct lsquic_send_ctl *ctl)
     TAILQ_FOREACH(packet_out, &ctl->sc_scheduled_packets, po_next)
     {
         assert(packet_out->po_flags & PO_SCHED);
-        bytes += packet_out_total_sz(packet_out);
+        bytes += packet_out->po_acct_sz;
         ++count;
     }
     assert(count == ctl->sc_n_scheduled);
@@ -2639,7 +2640,10 @@ update_for_resending (lsquic_send_ctl_t *ctl, lsquic_packet_out_t *packet_out)
     if (packet_out->po_regen_sz)
     {
         if (packet_out->po_flags & PO_SCHED)
+        {
             ctl->sc_bytes_scheduled -= packet_out->po_regen_sz;
+            packet_out->po_acct_sz -= packet_out->po_regen_sz;
+        }
         lsquic_packet_out_chop_regen(packet_out);
     }
     EV_LOG_CONN_EVENT(LSQUIC_LOG_CONN_ID, "schedule resend, repackage packet "
@@ -2725,6 +2729,7 @@ lsquic_send_ctl_elide_stream_frames (lsquic_send_ctl_t *ctl,
             adj = lsquic_packet_out_elide_reset_stream_frames(packet_out,
                                                               stream_id);
             ctl->sc_bytes_scheduled -= adj;
+            packet_out->po_acct_sz -= adj;
             if (0 == packet_out->po_frame_types)
             {
                 LSQ_DEBUG("cancel packet #%"PRIu64" after eliding frames for "
@@ -4072,6 +4077,7 @@ lsquic_send_ctl_cidlen_change (struct lsquic_send_ctl *ctl,
                                 unsigned orig_cid_len, unsigned new_cid_len)
 {
     unsigned diff;
+    struct lsquic_packet_out *p;
 
     assert(!(ctl->sc_conn_pub->lconn->cn_flags & LSCONN_SERVER));
     if (ctl->sc_n_scheduled)
@@ -4081,6 +4087,8 @@ lsquic_send_ctl_cidlen_change (struct lsquic_send_ctl *ctl,
         if (new_cid_len > orig_cid_len)
         {
             diff = new_cid_len - orig_cid_len;
+            TAILQ_FOREACH(p, &ctl->sc_scheduled_packets, po_next)
+                p->po_acct_sz += diff;
             diff *= ctl->sc_n_scheduled;
             ctl->sc_bytes_scheduled += diff;
             LSQ_DEBUG("increased bytes scheduled by %u bytes to %u",
@@ -4089,6 +4097,8 @@ lsquic_send_ctl_cidlen_change (struct lsquic_send_ctl *ctl,
         else if (new_cid_len < orig_cid_len)
         {
             diff = orig_cid_len - new_cid_len;
+            TAILQ_FOREACH(p, &ctl->sc_scheduled_packets, po_next)
+                p->po_acct_sz -= diff;
             diff *= ctl->sc_n_scheduled;
             ctl->sc_bytes_scheduled -= diff;
             LSQ_DEBUG("decreased bytes scheduled by %u bytes to %u",
@@ -4308,7 +4318,10 @@ lsquic_send_ctl_rollback (struct lsquic_send_ctl *ctl,
             packet_out->po_flags |= PO_STREAM_END;
         }
         if (!buffered)
+        {
             ctl->sc_bytes_scheduled -= prev_frec_len - frec->fe_len;
+            packet_out->po_acct_sz -= prev_frec_len - frec->fe_len;
+        }
     }
     else
         assert(stream_frame.data_frame.df_size

--- a/src/liblsquic/lsquic_send_ctl.h
+++ b/src/liblsquic/lsquic_send_ctl.h
@@ -412,7 +412,10 @@ lsquic_send_ctl_incr_pack_sz (struct lsquic_send_ctl *ctl,
 {
     packet->po_data_sz += delta;
     if (packet->po_flags & PO_SCHED)
+    {
         (ctl)->sc_bytes_scheduled += delta;
+        packet->po_acct_sz += delta;
+    }
     lsquic_send_ctl_sanity_check(ctl);
 }
 

--- a/src/liblsquic/lsquic_stream.c
+++ b/src/liblsquic/lsquic_stream.c
@@ -3292,7 +3292,10 @@ stream_write_to_packet_crypto (struct frame_gen_ctx *fg_ctx, const size_t size)
         lsquic_packet_out_zero_pad(packet_out);
         /* XXX: too hacky */
         if (before < packet_out->po_data_sz)
+        {
             send_ctl->sc_bytes_scheduled += packet_out->po_data_sz - before;
+            packet_out->po_acct_sz += packet_out->po_data_sz - before;
+        }
     }
 
     check_flush_threshold(stream);


### PR DESCRIPTION
Fixes #652.

**Problem.** `pf_packout_size` (`ietf_v1_packout_size`) is not a pure function of the packet — it reads `LSCONN_HANDSHAKE_DONE`, DCID length, and packet-number bits, which can change between schedule and send. So recomputing it at `send_ctl_sched_remove` does not cancel the value added at `send_ctl_sched_Xpend_common`, and the unsigned `sc_bytes_scheduled` drifts and can underflow to `~UINT_MAX`. Once that happens `send_ctl_can_send()` is stuck at 0 and the connection wedges (never tickable; `on_write` never dispatched).

**Fix.** Add `unsigned short po_acct_sz` to `struct lsquic_packet_out` — the exact on-wire size attributed to `sc_bytes_scheduled` when the packet was scheduled. Subtract this cached value at remove instead of recomputing `packet_out_total_sz()`, and keep `po_acct_sz` in lockstep with `sc_bytes_scheduled` everywhere the scheduled total is adjusted. The invariant `sc_bytes_scheduled == Σ_scheduled po_acct_sz` then holds after every operation, so the counter cannot drift or underflow regardless of any size-affecting state change between schedule and send. This mirrors how the unacked counter already caches and subtracts `po_sent_sz`.

**Changes (all in `src/liblsquic/`):**
- `lsquic_packet_out.h` — add `po_acct_sz`.
- `lsquic_send_ctl.c`
  - `send_ctl_sched_Xpend_common` — cache `po_acct_sz = packet_out_total_sz(p)`, add that.
  - `send_ctl_sched_remove` — subtract `po_acct_sz` instead of recomputing.
  - `lsquic_send_ctl_do_sanity_check` — sum `po_acct_sz`.
  - `update_for_resending` — on regen chop, `po_acct_sz -= po_regen_sz`.
  - `lsquic_send_ctl_elide_stream_frames` — on elide, `po_acct_sz -= adj`.
  - `lsquic_send_ctl_cidlen_change` — adjust each scheduled packet's `po_acct_sz` by the per-packet diff.
  - `lsquic_send_ctl_rollback` — `po_acct_sz -= prev_frec_len - fe_len`.
- `lsquic_send_ctl.h` — `lsquic_send_ctl_incr_pack_sz`: when scheduled, `po_acct_sz += delta`.
- `lsquic_stream.c` — `stream_write_to_packet_crypto`: the gQUIC HELLO zero-pad path grows `po_data_sz` and bumps `sc_bytes_scheduled` directly (bypassing `incr_pack_sz`); mirror the bump into `po_acct_sz` so the sanity check (which now sums `po_acct_sz`) and sched-remove stay consistent.

The previously-disabled `//assert(0 == ctl->sc_bytes_scheduled)` in `lsquic_send_ctl_cleanup` can now hold; left commented to keep the diff minimal (maintainer's call).

**Cost.** `sc_bytes_scheduled` now reflects schedule-time sizes; the only difference from the old behaviour is the handshake-done long-vs-short header delta (a few bytes) for packets that cross the flip — marginally more conservative, never an over-send. Negligible for congestion control.

**Testing.** Builds clean (gcc 13.3.0, `-Wall`, no new warnings). The accounting fix was validated in our deployment under a high-connection-count workload (~2000 concurrent IETF QUIC connections) that previously wedged within seconds — a connection stuck with `sc_n_scheduled == 0` yet `sc_bytes_scheduled == UINT_MAX` — and now sustains throughput to completion with the counter reaching 0 as expected. The gQUIC `stream.c` hunk is a by-inspection mirror of the existing direct `sc_bytes_scheduled` adjustment (gQUIC was not exercised at runtime).
