### PR TITLE
Fix: enforce stream concurrency limit in RST_STREAM processing

### DIFF
--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -5341,6 +5341,19 @@ process_rst_stream_frame (struct ietf_full_conn *conn,
             return 0;
         }
 
+        /* Enforce stream concurrency limit (RFC 9000 §4.6) */
+        {
+            const lsquic_stream_id_t max_allowed =
+                conn->ifc_max_allowed_stream_id[stream_id & SIT_MASK];
+            if (stream_id >= max_allowed)
+            {
+                ABORT_QUIETLY(0, TEC_STREAM_LIMIT_ERROR, "incoming RST_STREAM "
+                    "for stream %"PRIu64" would exceed allowed max of %"PRIu64,
+                    stream_id, max_allowed);
+                return 0;
+            }
+        }
+
         stream = new_stream(conn, stream_id, 0);
         if (!stream)
         {


### PR DESCRIPTION
process_rst_stream_frame did not check stream_id against ifc_max_allowed_stream_id[] before calling new_stream(), unlike process_stream_frame and process_stop_sending_frame. This allowed a peer to create stream state for stream IDs exceeding the advertised max_streams limit via RST_STREAM frames, causing unbounded memory growth (DoS).

Add the missing check and abort with TEC_STREAM_LIMIT_ERROR, consistent with the other frame handlers, as required by RFC 9000 §4.6.