### PR TITLE
Add send controller scheduled accounting tests

### DIFF
--- a/src/liblsquic/lsquic_send_ctl.c
+++ b/src/liblsquic/lsquic_send_ctl.c
@@ -4077,32 +4077,23 @@ lsquic_send_ctl_cidlen_change (struct lsquic_send_ctl *ctl,
                                 unsigned orig_cid_len, unsigned new_cid_len)
 {
     struct lsquic_packet_out *packet_out;
-    unsigned diff;
+    int diff, total_diff;
 
     assert(!(ctl->sc_conn_pub->lconn->cn_flags & LSCONN_SERVER));
     if (ctl->sc_n_scheduled)
     {
         ctl->sc_flags |= SC_CIDLEN;
         ctl->sc_cidlen = (signed char) new_cid_len - (signed char) orig_cid_len;
-        if (new_cid_len > orig_cid_len)
+        if (new_cid_len != orig_cid_len)
         {
-            diff = new_cid_len - orig_cid_len;
+            diff = (int) new_cid_len - (int) orig_cid_len;
+            total_diff = diff * (int) ctl->sc_n_scheduled;
             TAILQ_FOREACH(packet_out, &ctl->sc_scheduled_packets, po_next)
                 packet_out->po_acct_sz += diff;
-            diff *= ctl->sc_n_scheduled;
-            ctl->sc_bytes_scheduled += diff;
-            LSQ_DEBUG("increased bytes scheduled by %u bytes to %u",
-                diff, ctl->sc_bytes_scheduled);
-        }
-        else if (new_cid_len < orig_cid_len)
-        {
-            diff = orig_cid_len - new_cid_len;
-            TAILQ_FOREACH(packet_out, &ctl->sc_scheduled_packets, po_next)
-                packet_out->po_acct_sz -= diff;
-            diff *= ctl->sc_n_scheduled;
-            ctl->sc_bytes_scheduled -= diff;
-            LSQ_DEBUG("decreased bytes scheduled by %u bytes to %u",
-                diff, ctl->sc_bytes_scheduled);
+            ctl->sc_bytes_scheduled += total_diff;
+            LSQ_DEBUG("%s bytes scheduled by %d bytes to %u",
+                total_diff > 0 ? "increased" : "decreased",
+                abs(total_diff), ctl->sc_bytes_scheduled);
         }
         else
             LSQ_DEBUG("DCID length did not change");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ SET(TESTS
     rst_stream_gquic_be
     rtt
     send_headers
+    send_ctl_accounting
     send_ctl_bw_lifecycle
     senhist
     sess_resume

--- a/tests/test_h3_framing.c
+++ b/tests/test_h3_framing.c
@@ -430,6 +430,32 @@ deinit_test_objs (struct test_objs *tobjs)
 }
 
 
+static unsigned
+scheduled_acct_sum (const struct lsquic_send_ctl *send_ctl)
+{
+    const struct lsquic_packet_out *packet_out;
+    unsigned count, bytes;
+
+    count = 0;
+    bytes = 0;
+    TAILQ_FOREACH(packet_out, &send_ctl->sc_scheduled_packets, po_next)
+    {
+        assert(packet_out->po_flags & PO_SCHED);
+        bytes += packet_out->po_acct_sz;
+        ++count;
+    }
+    assert(count == send_ctl->sc_n_scheduled);
+    return bytes;
+}
+
+
+static void
+assert_scheduled_accounting (const struct lsquic_send_ctl *send_ctl)
+{
+    assert(scheduled_acct_sum(send_ctl) == send_ctl->sc_bytes_scheduled);
+}
+
+
 static struct lsquic_stream *
 new_stream (struct test_objs *tobjs, unsigned stream_id, uint64_t send_off)
 {
@@ -972,6 +998,7 @@ test_pwritev (enum lsquic_version version, int http, int sched_immed,
         lsquic_send_ctl_schedule_buffered(&tobjs.send_ctl, BPT_OTHER_PRIO);
         g_ctl_settings.tcs_schedule_stream_packets_immediately = 0;
         lsquic_send_ctl_set_max_bpq_count(10);
+        assert_scheduled_accounting(&tobjs.send_ctl);
     }
 
     assert(pwritev_stream_ctx.nw >= 0);

--- a/tests/test_send_ctl_accounting.c
+++ b/tests/test_send_ctl_accounting.c
@@ -1,0 +1,324 @@
+/* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/queue.h>
+
+#include "lsquic.h"
+#include "lsquic_int_types.h"
+#include "lsquic_types.h"
+#include "lsquic_packet_common.h"
+#include "lsquic_alarmset.h"
+#include "lsquic_conn_flow.h"
+#include "lsquic_rtt.h"
+#include "lsquic_sfcw.h"
+#include "lsquic_varint.h"
+#include "lsquic_hq.h"
+#include "lsquic_hash.h"
+#include "lsquic_stream.h"
+#include "lsquic_mm.h"
+#include "lsquic_conn_public.h"
+#include "lsquic_parse.h"
+#include "lsquic_conn.h"
+#include "lsquic_engine_public.h"
+#include "lsquic_cubic.h"
+#include "lsquic_pacer.h"
+#include "lsquic_senhist.h"
+#include "lsquic_bw_sampler.h"
+#include "lsquic_minmax.h"
+#include "lsquic_bbr.h"
+#include "lsquic_adaptive_cc.h"
+#include "lsquic_send_ctl.h"
+#include "lsquic_ver_neg.h"
+#include "lsquic_packet_out.h"
+#include "lsquic_malo.h"
+#include "lsquic_enc_sess.h"
+
+
+struct accounting_test
+{
+    struct lsquic_conn           lconn;
+    struct lsquic_engine_public  enpub;
+    struct lsquic_conn_public    conn_pub;
+    struct lsquic_send_ctl       send_ctl;
+    struct lsquic_alarmset       alset;
+    struct ver_neg               ver_neg;
+    struct network_path          path;
+};
+
+
+static void
+set_dcid_len (struct network_path *path, unsigned len)
+{
+    unsigned i;
+
+    assert(len <= sizeof(path->np_dcid.idbuf));
+    path->np_dcid.len = len;
+    for (i = 0; i < len; ++i)
+        path->np_dcid.idbuf[i] = (unsigned char) (0xA0 + i);
+}
+
+
+static void
+init_test (struct accounting_test *t)
+{
+    memset(t, 0, sizeof(*t));
+    LSCONN_INITIALIZE(&t->lconn);
+    t->lconn.cn_flags |= LSCONN_IETF|LSCONN_HANDSHAKE_DONE;
+    t->lconn.cn_version = LSQVER_I001;
+    t->lconn.cn_pf = select_pf_by_ver(LSQVER_I001);
+    t->lconn.cn_esf_c = &lsquic_enc_session_common_ietf_v1;
+
+    lsquic_engine_init_settings(&t->enpub.enp_settings, 0);
+    t->enpub.enp_settings.es_cc_algo = 1;  /* Cubic */
+    lsquic_mm_init(&t->enpub.enp_mm);
+    lsquic_alarmset_init(&t->alset, 0);
+
+    TAILQ_INIT(&t->conn_pub.sending_streams);
+    TAILQ_INIT(&t->conn_pub.read_streams);
+    TAILQ_INIT(&t->conn_pub.write_streams);
+    TAILQ_INIT(&t->conn_pub.service_streams);
+    t->path.np_pack_size = 1370;
+    t->path.np_path_id = 0;
+    set_dcid_len(&t->path, 8);
+    t->conn_pub.mm = &t->enpub.enp_mm;
+    t->conn_pub.lconn = &t->lconn;
+    t->conn_pub.enpub = &t->enpub;
+    t->conn_pub.send_ctl = &t->send_ctl;
+    t->conn_pub.path = &t->path;
+    t->conn_pub.packet_out_malo =
+                        lsquic_malo_create(sizeof(struct lsquic_packet_out));
+    assert(t->conn_pub.packet_out_malo);
+
+    lsquic_send_ctl_init(&t->send_ctl, &t->alset, &t->enpub, &t->ver_neg,
+                                                &t->conn_pub, SC_IETF);
+}
+
+
+static void
+cleanup_test (struct accounting_test *t)
+{
+    lsquic_send_ctl_cleanup(&t->send_ctl);
+    lsquic_malo_destroy(t->conn_pub.packet_out_malo);
+    lsquic_mm_cleanup(&t->enpub.enp_mm);
+}
+
+
+static unsigned
+scheduled_acct_sum (const struct accounting_test *t)
+{
+    const struct lsquic_packet_out *packet_out;
+    unsigned count, bytes;
+
+    count = 0;
+    bytes = 0;
+    TAILQ_FOREACH(packet_out, &t->send_ctl.sc_scheduled_packets, po_next)
+    {
+        assert(packet_out->po_flags & PO_SCHED);
+        bytes += packet_out->po_acct_sz;
+        ++count;
+    }
+    assert(count == t->send_ctl.sc_n_scheduled);
+    return bytes;
+}
+
+
+static void
+assert_scheduled_accounting (const struct accounting_test *t)
+{
+    assert(scheduled_acct_sum(t) == t->send_ctl.sc_bytes_scheduled);
+}
+
+
+static struct lsquic_packet_out *
+new_ping_packet (struct accounting_test *t, unsigned short data_sz)
+{
+    struct lsquic_packet_out *packet_out;
+
+    packet_out = lsquic_send_ctl_new_packet_out(&t->send_ctl, 0, PNS_APP,
+                                                                    &t->path);
+    assert(packet_out);
+    assert(packet_out->po_flags & PO_CONN_ID);
+    packet_out->po_frame_types = QUIC_FTBIT_PING;
+    memset(packet_out->po_data, 0x01, data_sz);
+    packet_out->po_data_sz = data_sz;
+    return packet_out;
+}
+
+
+static struct lsquic_packet_out *
+schedule_ping_packet (struct accounting_test *t, unsigned short data_sz)
+{
+    struct lsquic_packet_out *packet_out;
+
+    packet_out = new_ping_packet(t, data_sz);
+    lsquic_send_ctl_scheduled_one(&t->send_ctl, packet_out);
+    assert(packet_out->po_acct_sz > data_sz);
+    assert_scheduled_accounting(t);
+    return packet_out;
+}
+
+
+static void
+destroy_unscheduled_packet (struct accounting_test *t,
+                            struct lsquic_packet_out *packet_out)
+{
+    assert(0 == (packet_out->po_flags & PO_SCHED));
+    lsquic_packet_out_destroy(packet_out, &t->enpub, NULL);
+}
+
+
+static void
+test_dcid_change_next_packet_to_send (void)
+{
+    struct accounting_test t;
+    struct lsquic_packet_out *packet_out;
+
+    init_test(&t);
+    (void) schedule_ping_packet(&t, 1);
+    set_dcid_len(&t.path, 20);
+    packet_out = lsquic_send_ctl_next_packet_to_send(&t.send_ctl, NULL);
+    assert(packet_out);
+    assert(0 == t.send_ctl.sc_n_scheduled);
+    assert(0 == t.send_ctl.sc_bytes_scheduled);
+    destroy_unscheduled_packet(&t, packet_out);
+    cleanup_test(&t);
+}
+
+
+static void
+test_dcid_change_cleanup (void)
+{
+    struct accounting_test t;
+
+    init_test(&t);
+    (void) schedule_ping_packet(&t, 1);
+    set_dcid_len(&t.path, 20);
+    cleanup_test(&t);
+}
+
+
+static void
+test_dcid_change_drop_scheduled (void)
+{
+    struct accounting_test t;
+
+    init_test(&t);
+    (void) schedule_ping_packet(&t, 1);
+    set_dcid_len(&t.path, 20);
+    lsquic_send_ctl_drop_scheduled(&t.send_ctl);
+    assert(0 == t.send_ctl.sc_n_scheduled);
+    assert(0 == t.send_ctl.sc_bytes_scheduled);
+    cleanup_test(&t);
+}
+
+
+static void
+test_incr_pack_sz (void)
+{
+    struct accounting_test t;
+    struct lsquic_packet_out *packet_out;
+    unsigned bytes_before, acct_before;
+
+    init_test(&t);
+    packet_out = schedule_ping_packet(&t, 0);
+    bytes_before = t.send_ctl.sc_bytes_scheduled;
+    acct_before = packet_out->po_acct_sz;
+    lsquic_send_ctl_incr_pack_sz(&t.send_ctl, packet_out, 9);
+    assert(t.send_ctl.sc_bytes_scheduled == bytes_before + 9);
+    assert(packet_out->po_acct_sz == acct_before + 9);
+    assert_scheduled_accounting(&t);
+    packet_out = lsquic_send_ctl_next_packet_to_send(&t.send_ctl, NULL);
+    assert(packet_out);
+    assert(0 == t.send_ctl.sc_bytes_scheduled);
+    destroy_unscheduled_packet(&t, packet_out);
+    cleanup_test(&t);
+}
+
+
+static void
+test_cidlen_change_adjusts_cached_sizes (void)
+{
+    struct accounting_test t;
+    struct lsquic_packet_out *packet_one, *packet_two;
+    unsigned first_acct, second_acct, total;
+
+    init_test(&t);
+    packet_one = schedule_ping_packet(&t, 1);
+    packet_two = schedule_ping_packet(&t, 2);
+    first_acct = packet_one->po_acct_sz;
+    second_acct = packet_two->po_acct_sz;
+    total = t.send_ctl.sc_bytes_scheduled;
+
+    lsquic_send_ctl_cidlen_change(&t.send_ctl, 8, 20);
+    assert(packet_one->po_acct_sz == first_acct + 12);
+    assert(packet_two->po_acct_sz == second_acct + 12);
+    assert(t.send_ctl.sc_bytes_scheduled == total + 24);
+    assert_scheduled_accounting(&t);
+
+    lsquic_send_ctl_cidlen_change(&t.send_ctl, 20, 8);
+    assert(packet_one->po_acct_sz == first_acct);
+    assert(packet_two->po_acct_sz == second_acct);
+    assert(t.send_ctl.sc_bytes_scheduled == total);
+    assert_scheduled_accounting(&t);
+
+    cleanup_test(&t);
+}
+
+
+static void
+test_repackno_chops_regen_bytes (void)
+{
+    struct accounting_test t;
+    struct lsquic_packet_out *packet_out;
+    unsigned acct_before;
+    int s;
+
+    init_test(&t);
+    packet_out = lsquic_send_ctl_new_packet_out(&t.send_ctl, 0, PNS_APP,
+                                                                    &t.path);
+    assert(packet_out);
+    memset(packet_out->po_data, 0, 3);
+    packet_out->po_data[0] = 0x02;
+    packet_out->po_data[1] = 0x02;
+    packet_out->po_data[2] = 0x01;
+    packet_out->po_data_sz = 3;
+    packet_out->po_regen_sz = 2;
+    packet_out->po_frame_types = QUIC_FTBIT_ACK|QUIC_FTBIT_PING;
+    packet_out->po_flags |= PO_REPACKNO;
+    s = lsquic_packet_out_add_frame(packet_out, &t.enpub.enp_mm, 0,
+                                    QUIC_FRAME_ACK, 0, 2);
+    assert(0 == s);
+    s = lsquic_packet_out_add_frame(packet_out, &t.enpub.enp_mm, 0,
+                                    QUIC_FRAME_PING, 2, 1);
+    assert(0 == s);
+    lsquic_send_ctl_scheduled_one(&t.send_ctl, packet_out);
+    acct_before = packet_out->po_acct_sz;
+    assert_scheduled_accounting(&t);
+
+    packet_out = lsquic_send_ctl_next_packet_to_send(&t.send_ctl, NULL);
+    assert(packet_out);
+    assert(packet_out->po_acct_sz == acct_before - 2);
+    assert(0 == packet_out->po_regen_sz);
+    assert(0 == (packet_out->po_frame_types & QUIC_FTBIT_ACK));
+    assert(packet_out->po_frame_types & QUIC_FTBIT_PING);
+    assert(0 == t.send_ctl.sc_bytes_scheduled);
+
+    destroy_unscheduled_packet(&t, packet_out);
+    cleanup_test(&t);
+}
+
+
+int
+main (void)
+{
+    test_dcid_change_next_packet_to_send();
+    test_dcid_change_cleanup();
+    test_dcid_change_drop_scheduled();
+    test_incr_pack_sz();
+    test_cidlen_change_adjusts_cached_sizes();
+    test_repackno_chops_regen_bytes();
+    return 0;
+}

--- a/tests/test_stream.c
+++ b/tests/test_stream.c
@@ -421,6 +421,32 @@ deinit_test_objs (struct test_objs *tobjs)
 }
 
 
+static unsigned
+scheduled_acct_sum (const struct lsquic_send_ctl *send_ctl)
+{
+    const struct lsquic_packet_out *packet_out;
+    unsigned count, bytes;
+
+    count = 0;
+    bytes = 0;
+    TAILQ_FOREACH(packet_out, &send_ctl->sc_scheduled_packets, po_next)
+    {
+        assert(packet_out->po_flags & PO_SCHED);
+        bytes += packet_out->po_acct_sz;
+        ++count;
+    }
+    assert(count == send_ctl->sc_n_scheduled);
+    return bytes;
+}
+
+
+static void
+assert_scheduled_accounting (const struct lsquic_send_ctl *send_ctl)
+{
+    assert(scheduled_acct_sum(send_ctl) == send_ctl->sc_bytes_scheduled);
+}
+
+
 /* Create a new stream frame.  Each stream frame has a real packet_in to
  * back it up, just like in real code.  The contents of the packet do
  * not matter.
@@ -1352,6 +1378,7 @@ test_gapless_elision_middle (struct test_objs *tobjs)
     else
         assert(s_onreset_called.how == 2);
     assert(2 == lsquic_send_ctl_n_scheduled(&tobjs->send_ctl));
+    assert_scheduled_accounting(&tobjs->send_ctl);
     /* Verify A again: */
     n = read_from_scheduled_packets(&tobjs->send_ctl, streamA->id, buf,
                                                     sizeof(buf), 0, &fin, 0);
@@ -1429,6 +1456,7 @@ test_gapless_elision_beginning (struct test_objs *tobjs)
     }
     assert(streamB->stream_flags & STREAM_FRAMES_ELIDED);
     assert(2 == lsquic_send_ctl_n_scheduled(&tobjs->send_ctl));
+    assert_scheduled_accounting(&tobjs->send_ctl);
     /* Verify A again: */
     n = read_from_scheduled_packets(&tobjs->send_ctl, streamA->id, buf,
                                                     sizeof(buf), 0, &fin, 0);
@@ -3102,11 +3130,13 @@ test_resize_scheduled (void)
                                                 g_ctl_settings.tcs_bp_type);
     packet_counts[0] = lsquic_send_ctl_n_scheduled(&tobjs.send_ctl);
     assert(packet_counts[0] > 0);
+    assert_scheduled_accounting(&tobjs.send_ctl);
 
     network_path.np_pack_size = 1234;
     lsquic_send_ctl_resize(&tobjs.send_ctl);
     packet_counts[1] = lsquic_send_ctl_n_scheduled(&tobjs.send_ctl);
     assert(packet_counts[1] > packet_counts[0]);
+    assert_scheduled_accounting(&tobjs.send_ctl);
 
     /* Verify written data: */
     nw = read_from_scheduled_packets(&tobjs.send_ctl, streams[0]->id, buf_out,
@@ -3114,6 +3144,7 @@ test_resize_scheduled (void)
     assert(nw == sizeof(buf));
     assert(fin);
     assert(0 == memcmp(buf, buf_out, nw));
+    assert_scheduled_accounting(&tobjs.send_ctl);
 
     lsquic_stream_destroy(streams[0]);
     deinit_test_objs(&tobjs);


### PR DESCRIPTION
## Summary
- add a focused send controller unit test for sc_bytes_scheduled/po_acct_sz accounting
- cover DCID length changes after scheduling across dequeue, cleanup, and drop paths
- add accounting assertions to stream resize, stream-frame elision, and h3 pwritev scheduling tests

## Testing
- ctest --test-dir /tmp/lsquic-sendctl-accounting-build-debug -R '^(send_ctl_accounting|stream|h3_framing_pwritev_combo[0-5])$' --output-on-failure