### PR TITLE
Release 4.9.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+2026-07-26
+    - 4.9.1
+    - [FIX, SPEC] Require 3 uni streams for HTTP/3 connections
+    - [FIX] Abort connection when STOP_SENDING comes in for a critical stream
+    - [FIX] Fix unreadable HQ filter error state
+    - [FIX] Reset errno before parsing content length
+    - [FIX] Use ls-qpack 2.6.6 to pick up latest fix
+    - [FIX] Abort if QDEC handler cannot write to fral-backed stream
+
 2026-07-15
     - 4.9.0
     - [API, IMPROVEMENT] Limit number of buffered header sets to cap

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = u'LiteSpeed Technologies'
 # The short X.Y version
 version = u'4.9'
 # The full version, including alpha/beta/rc tags
-release = u'4.9.0'
+release = u'4.9.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #define LSQUIC_MAJOR_VERSION 4
 #define LSQUIC_MINOR_VERSION 9
-#define LSQUIC_PATCH_VERSION 0
+#define LSQUIC_PATCH_VERSION 1
 
 #define LSQUIC_QUOTE(x)     #x
 #define LSQUIC_SVAL(v)      LSQUIC_QUOTE(v)

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -3706,11 +3706,10 @@ init_http (struct ietf_full_conn *conn)
             conn->ifc_qeh.qeh_exp_rec->qer_flags |= QER_ENCODER;
         }
     }
-    if (0 == avail_streams_count(conn, conn->ifc_flags & IFC_SERVER,
-                                                                SD_UNI))
+    if (avail_streams_count(conn, conn->ifc_flags & IFC_SERVER, SD_UNI) < 3)
     {
         ABORT_QUIETLY(1, HEC_GENERAL_PROTOCOL_ERROR, "cannot create "
-                            "control stream due to peer-imposed limit");
+                    "control and QPACK streams due to peer-imposed limit");
         conn->ifc_error = CONN_ERR(1, HEC_GENERAL_PROTOCOL_ERROR);
         return -1;
     }
@@ -3737,27 +3736,19 @@ init_http (struct ietf_full_conn *conn)
         ABORT_WARN("cannot write SETTINGS");
         return -1;
     }
-    if (0 != lsquic_qdh_init(&conn->ifc_qdh, &conn->ifc_conn,
-                            conn->ifc_flags & IFC_SERVER, conn->ifc_enpub,
-                            dyn_table_size, max_risked_streams))
+
+    /* QDH initialization must precede outgoing decoder stream creation:
+     * create_qdec_stream_out() synchronously invokes qdh_out_on_new().
+     */
+    lsquic_qdh_init(&conn->ifc_qdh, &conn->ifc_conn,
+                        conn->ifc_flags & IFC_SERVER, conn->ifc_enpub,
+                        dyn_table_size, max_risked_streams);
+    if (0 != create_qdec_stream_out(conn))
     {
-        ABORT_WARN("cannot initialize QPACK decoder");
+        ABORT_WARN("cannot create outgoing QPACK decoder stream");
         return -1;
     }
-    if (avail_streams_count(conn, conn->ifc_flags & IFC_SERVER, SD_UNI) > 0)
-    {
-        if (0 != create_qdec_stream_out(conn))
-        {
-            ABORT_WARN("cannot create outgoing QPACK decoder stream");
-            return -1;
-        }
-    }
-    else
-    {
-        queue_streams_blocked_frame(conn, SD_UNI);
-        LSQ_DEBUG("cannot create outgoing QPACK decoder stream due to "
-            "unidir limits");
-    }
+
     conn->ifc_flags |= IFC_HTTP_INITED;
     return 0;
 }
@@ -5414,7 +5405,15 @@ process_stop_sending_frame (struct ietf_full_conn *conn,
     our_stream = !is_peer_initiated(conn, stream_id);
     stream = find_stream_by_id(conn, stream_id);
     if (stream)
+    {
+        if (lsquic_stream_is_critical(stream))
+        {
+            ABORT_QUIETLY(1, HEC_CLOSED_CRITICAL_STREAM,
+                "received STOP_SENDING on critical stream %"PRIu64, stream_id);
+            return 0;
+        }
         lsquic_stream_stop_sending_in(stream, error_code);
+    }
     else if (conn_is_stream_closed(conn, stream_id))
         LSQ_DEBUG("stream %"PRIu64" is closed: ignore STOP_SENDING frame",
             stream_id);
@@ -9609,6 +9608,8 @@ static void
 apply_uni_stream_class (struct ietf_full_conn *conn,
                             struct lsquic_stream *stream, uint64_t stream_type)
 {
+    assert(conn->ifc_flags & IFC_HTTP_INITED);
+
     switch (stream_type)
     {
     case HQUST_CONTROL:
@@ -9816,6 +9817,38 @@ lsquic_ietf_full_conn_test_push_disabled (unsigned results[5])
     conn.ifc_flags = IFC_SERVER;
     abort_push_stream(&conn);
     results[PUSH_STREAM_SERVER] = conn.ifc_error.u.err;
+    free(conn.ifc_errmsg);
+}
+
+
+void
+lsquic_ietf_full_conn_test_stop_sending_critical (unsigned results[4])
+{
+    struct ietf_full_conn conn;
+    struct lsquic_stream stream;
+    unsigned char frame[32];
+    int len;
+
+    memset(&conn, 0, sizeof(conn));
+    memset(&stream, 0, sizeof(stream));
+    conn.ifc_flags = IFC_HTTP;
+    conn.ifc_conn.cn_pf = select_pf_by_ver(LSQVER_I001);
+    conn.ifc_pub.all_streams = lsquic_hash_create();
+    assert(conn.ifc_pub.all_streams);
+    stream.id = 2;  /* Client-initiated unidirectional stream */
+    stream.sm_bflags = SMBF_CRITICAL;
+    assert(lsquic_hash_insert(conn.ifc_pub.all_streams, &stream.id,
+                    sizeof(stream.id), &stream, &stream.sm_hash_el));
+
+    len = conn.ifc_conn.cn_pf->pf_gen_stop_sending_frame(frame, sizeof(frame),
+                                                            stream.id, 0);
+    assert(len > 0);
+    results[0] = process_stop_sending_frame(&conn, NULL, frame, len);
+    results[1] = conn.ifc_error.app_error;
+    results[2] = conn.ifc_error.u.err;
+    results[3] = !!(stream.stream_flags & STREAM_SS_RECVD);
+
+    lsquic_hash_destroy(conn.ifc_pub.all_streams);
     free(conn.ifc_errmsg);
 }
 

--- a/src/liblsquic/lsquic_qdec_hdl.c
+++ b/src/liblsquic/lsquic_qdec_hdl.c
@@ -74,7 +74,7 @@ qdh_write_decoder (struct qpack_dec_hdl *qdh, const unsigned char *buf,
 {
     ssize_t nw;
 
-    if (!(qdh->qdh_dec_sm_out && lsquic_frab_list_empty(&qdh->qdh_fral)))
+    if (!lsquic_frab_list_empty(&qdh->qdh_fral))
     {
   write_to_frab:
         if (0 == lsquic_frab_list_write(&qdh->qdh_fral,
@@ -156,7 +156,7 @@ qdh_begin_out (struct qpack_dec_hdl *qdh)
 }
 
 
-int
+void
 lsquic_qdh_init (struct qpack_dec_hdl *qdh, struct lsquic_conn *conn,
                     int is_server, const struct lsquic_engine_public *enpub,
                     unsigned dyn_table_size, unsigned max_risked_streams)
@@ -204,12 +204,10 @@ lsquic_qdh_init (struct qpack_dec_hdl *qdh, struct lsquic_conn *conn,
     }
     else
         qdh->qdh_hsi_ctx = qdh->qdh_enpub->enp_hsi_ctx;
-    if (qdh->qdh_dec_sm_out)
-        qdh_begin_out(qdh);
+    assert(!qdh->qdh_dec_sm_out);   /* Expect init before stream creation */
     if (qdh->qdh_enc_sm_in)
         lsquic_stream_wantread(qdh->qdh_enc_sm_in, 1);
     LSQ_DEBUG("initialized");
-    return 0;
 }
 
 
@@ -252,8 +250,8 @@ qdh_out_on_new (void *stream_if_ctx, struct lsquic_stream *stream)
 {
     struct qpack_dec_hdl *const qdh = stream_if_ctx;
     qdh->qdh_dec_sm_out = stream;
-    if (qdh->qdh_flags & QDH_INITIALIZED)
-        qdh_begin_out(qdh);
+    assert(qdh->qdh_flags & QDH_INITIALIZED);
+    qdh_begin_out(qdh);
     LSQ_DEBUG("initialized outgoing decoder stream");
     return (void *) qdh;
 }
@@ -356,9 +354,10 @@ static lsquic_stream_ctx_t *
 qdh_in_on_new (void *stream_if_ctx, struct lsquic_stream *stream)
 {
     struct qpack_dec_hdl *const qdh = stream_if_ctx;
+    assert(qdh->qdh_dec_sm_out);
+    assert(qdh->qdh_flags & QDH_INITIALIZED);
     qdh->qdh_enc_sm_in = stream;
-    if (qdh->qdh_flags & QDH_INITIALIZED)
-        lsquic_stream_wantread(qdh->qdh_enc_sm_in, 1);
+    lsquic_stream_wantread(qdh->qdh_enc_sm_in, 1);
     LSQ_DEBUG("initialized incoming encoder stream");
     return (void *) qdh;
 }
@@ -390,8 +389,7 @@ qdh_read_encoder_stream (void *ctx, const unsigned char *buf, size_t sz,
             "stream; offset %"PRIu64", line %d", qerr->off, qerr->line);
         goto end;
     }
-    if (qdh->qdh_dec_sm_out
-                    && lsqpack_dec_ici_pending(&qdh->qdh_decoder))
+    if (lsqpack_dec_ici_pending(&qdh->qdh_decoder))
         lsquic_stream_wantwrite(qdh->qdh_dec_sm_out, 1);
 
     LSQ_DEBUG("successfully fed %zu bytes to QPACK decoder", sz);
@@ -487,6 +485,7 @@ process_content_length (const struct qpack_dec_hdl *qdh /* for logging */,
         }
     memcpy(cont_len_buf, val, len);
     cont_len_buf[len] = '\0';
+    errno = 0;
     value = strtoull(cont_len_buf, &endcl, 10);
 
     if (*endcl == '\0' && !(ULLONG_MAX == value && ERANGE == errno))
@@ -708,16 +707,13 @@ qdh_header_read_results (struct qpack_dec_hdl *qdh,
             LSQ_DEBUG("discard trailer header set");
             qdh_maybe_destroy_hblock_ctx(qdh, stream);
         }
-        if (qdh->qdh_dec_sm_out)
+        if (dec_buf_sz
+            && 0 != qdh_write_decoder(qdh, dec_buf, dec_buf_sz))
         {
-            if (dec_buf_sz
-                && 0 != qdh_write_decoder(qdh, dec_buf, dec_buf_sz))
-            {
-                return LQRHS_ERROR;
-            }
-            if (dec_buf_sz || lsqpack_dec_ici_pending(&qdh->qdh_decoder))
-                lsquic_stream_wantwrite(qdh->qdh_dec_sm_out, 1);
+            return LQRHS_ERROR;
         }
+        if (dec_buf_sz || lsqpack_dec_ici_pending(&qdh->qdh_decoder))
+            lsquic_stream_wantwrite(qdh->qdh_dec_sm_out, 1);
     }
     else if (rhs == LQRHS_ERROR)
     {
@@ -848,15 +844,15 @@ lsquic_qdh_cancel_stream (struct qpack_dec_hdl *qdh,
 
     qdh_maybe_destroy_hblock_ctx(qdh, stream);
 
-    if (!qdh->qdh_dec_sm_out)
-        return;
-
     nw = lsqpack_dec_cancel_stream(&qdh->qdh_decoder, stream, buf, sizeof(buf));
     if (nw > 0)
     {
         if (0 == qdh_write_decoder(qdh, buf, nw))
             LSQ_DEBUG("cancelled stream %"PRIu64" and wrote %zd-byte Cancel "
                 "Stream instruction to the decoder stream", stream->id, nw);
+        else
+            qdh->qdh_conn->cn_if->ci_internal_error(qdh->qdh_conn,
+                                            "cannot write to stream");
     }
     else if (nw == 0)
         LSQ_WARN("cannot cancel stream %"PRIu64" -- not found", stream->id);
@@ -876,9 +872,6 @@ lsquic_qdh_cancel_stream_id (struct qpack_dec_hdl *qdh,
     ssize_t nw;
     unsigned char buf[LSQPACK_LONGEST_CANCEL];
 
-    if (!qdh->qdh_dec_sm_out)
-        return;
-
     nw = lsqpack_dec_cancel_stream_id(&qdh->qdh_decoder, stream_id, buf,
                                                                 sizeof(buf));
     if (nw > 0)
@@ -886,6 +879,9 @@ lsquic_qdh_cancel_stream_id (struct qpack_dec_hdl *qdh,
         if (0 == qdh_write_decoder(qdh, buf, nw))
             LSQ_DEBUG("wrote %zd-byte Cancel Stream instruction for "
                 "stream %"PRIu64" to the decoder stream", nw, stream_id);
+        else
+            qdh->qdh_conn->cn_if->ci_internal_error(qdh->qdh_conn,
+                                            "cannot write to stream");
     }
     else if (nw == 0)
         LSQ_DEBUG("not generating Cancel Stream instruction for "

--- a/src/liblsquic/lsquic_qdec_hdl.h
+++ b/src/liblsquic/lsquic_qdec_hdl.h
@@ -40,7 +40,7 @@ struct qpack_dec_hdl
     char                    *qdh_ua;
 };
 
-int
+void
 lsquic_qdh_init (struct qpack_dec_hdl *, struct lsquic_conn *,
                     int is_server, const struct lsquic_engine_public *,
                     unsigned dyn_table_size, unsigned max_risked_streams);

--- a/src/liblsquic/lsquic_stream.c
+++ b/src/liblsquic/lsquic_stream.c
@@ -826,6 +826,8 @@ stream_readable_http_ietf (struct lsquic_stream *stream)
         (stream->sm_sfi->sfi_readable(stream)
             && (/* Running the filter may result in hitting FIN: */
                 (stream->stream_flags & STREAM_FIN_REACHED)
+                /* Or in HTTP/3 error */
+                || (stream->sm_hq_filter.hqfi_flags & HQFI_FLAG_ERROR)
                 /* Or in decoding the last buffered frame into a header set: */
                 || !STAILQ_EMPTY(&stream->uh)
                 || stream_has_frame_at_read_offset(stream)));

--- a/tests/test_h3_framing.c
+++ b/tests/test_h3_framing.c
@@ -527,14 +527,10 @@ static const struct lsquic_hset_if test_hset_if =
 static void
 use_test_hset_if (struct test_objs *tobjs)
 {
-    int s;
-
     lsquic_qdh_cleanup(&tobjs->qdh);
     tobjs->eng_pub.enp_hsi_if = &test_hset_if;
     tobjs->eng_pub.enp_hsi_ctx = NULL;
-    s = lsquic_qdh_init(&tobjs->qdh, &tobjs->lconn, 0, &tobjs->eng_pub,
-                                                                    0, 0);
-    assert(0 == s);
+    lsquic_qdh_init(&tobjs->qdh, &tobjs->lconn, 0, &tobjs->eng_pub, 0, 0);
     tobjs->conn_pub.u.ietf.qdh = &tobjs->qdh;
 }
 
@@ -2143,7 +2139,7 @@ test_reading_zero_size_data_frame_scenario3 (void)
 static void
 expect_header_block_result (struct lsxpack_header *hdrs, unsigned count,
                             int expect_abort,
-                            unsigned long long content_len)
+                            unsigned long long content_len, int initial_errno)
 {
     struct test_objs sender, receiver;
     struct lsquic_stream *send_stream, *recv_stream;
@@ -2180,6 +2176,7 @@ expect_header_block_result (struct lsxpack_header *hdrs, unsigned count,
     recv_stream = new_stream(&receiver, 0, 0x1000);
 
     frame = new_frame_in_ext(&receiver, 0, nw, fin, buf);
+    errno = initial_errno;
     s = lsquic_stream_frame_in(recv_stream, frame);
     assert(0 == s);
 
@@ -2216,7 +2213,7 @@ expect_header_block_result (struct lsxpack_header *hdrs, unsigned count,
 static void
 expect_header_block_abort (struct lsxpack_header *hdrs, unsigned count)
 {
-    expect_header_block_result(hdrs, count, 1, 0);
+    expect_header_block_result(hdrs, count, 1, 0, 0);
 }
 
 
@@ -2224,7 +2221,7 @@ static void
 expect_header_block_accept (struct lsxpack_header *hdrs, unsigned count,
                                                 unsigned long long content_len)
 {
-    expect_header_block_result(hdrs, count, 0, content_len);
+    expect_header_block_result(hdrs, count, 0, content_len, 0);
 }
 
 
@@ -2344,6 +2341,37 @@ test_content_length_overrun_blocks_payload_delivery (void)
 }
 
 
+static void
+test_content_length_max_value_ignores_stale_errno (void)
+{
+    struct lsxpack_header hdrs[] = {
+        { XHDR(":method", "GET") },
+        { XHDR(":scheme", "https") },
+        { XHDR(":path", "/") },
+        { XHDR(":authority", "example.com") },
+        { XHDR("content-length", "18446744073709551615") },
+    };
+
+    expect_header_block_result(hdrs, sizeof(hdrs) / sizeof(hdrs[0]), 0,
+                                                    ULLONG_MAX, ERANGE);
+}
+
+
+static void
+test_content_length_overflow_is_rejected (void)
+{
+    struct lsxpack_header hdrs[] = {
+        { XHDR(":method", "GET") },
+        { XHDR(":scheme", "https") },
+        { XHDR(":path", "/") },
+        { XHDR(":authority", "example.com") },
+        { XHDR("content-length", "18446744073709551616") },
+    };
+
+    expect_header_block_abort(hdrs, sizeof(hdrs) / sizeof(hdrs[0]));
+}
+
+
 int
 main (int argc, char **argv)
 {
@@ -2427,6 +2455,8 @@ main (int argc, char **argv)
             test_content_length_overrun_blocks_payload_delivery();
             test_coalesced_hsets_are_throttled();
             test_data_waits_for_hset_claim();
+            test_content_length_max_value_ignores_stale_errno();
+            test_content_length_overflow_is_rejected();
             break;
         default:
             fprintf(stderr, "Unknown test subset: %d\n", test_subset);
@@ -2453,6 +2483,8 @@ main (int argc, char **argv)
         test_conflicting_content_length_is_rejected();
         test_invalid_content_length_syntax_is_rejected();
         test_content_length_overrun_blocks_payload_delivery();
+        test_content_length_max_value_ignores_stale_errno();
+        test_content_length_overflow_is_rejected();
     }
 
     return 0;

--- a/tests/test_http_prio_header.c
+++ b/tests/test_http_prio_header.c
@@ -179,9 +179,7 @@ init_test_objs (struct test_objs *tobjs)
     lsquic_qeh_init(&tobjs->qeh, &tobjs->lconn);
     s = lsquic_qeh_settings(&tobjs->qeh, 0, 0, 0, 0);
     assert(0 == s);
-    s = lsquic_qdh_init(&tobjs->qdh, &tobjs->lconn, 1,
-                        tobjs->conn_pub.enpub, 0, 0);
-    assert(0 == s);
+    lsquic_qdh_init(&tobjs->qdh, &tobjs->lconn, 1, tobjs->conn_pub.enpub, 0, 0);
     tobjs->conn_pub.u.ietf.qdh = &tobjs->qdh;
 }
 

--- a/tests/test_send_headers.c
+++ b/tests/test_send_headers.c
@@ -252,10 +252,9 @@ init_test_objs (struct test_objs *tobjs, unsigned initial_conn_window,
         tobjs->conn_pub.u.ietf.qeh = &tobjs->qeh;
         tobjs->conn_pub.enpub->enp_hsi_if  = lsquic_http1x_if;
         tobjs->conn_pub.enpub->enp_hsi_ctx = &ctor_ctx;
-        s = lsquic_qdh_init(&tobjs->qdh, &tobjs->lconn, 0,
+        lsquic_qdh_init(&tobjs->qdh, &tobjs->lconn, 0,
                                     tobjs->conn_pub.enpub, 0, 0);
         tobjs->conn_pub.u.ietf.qdh = &tobjs->qdh;
-        assert(0 == s);
     }
 }
 
@@ -859,6 +858,39 @@ test_read_headers_http1x (void)
 }
 
 
+static void
+test_hq_filter_error_is_readable (void)
+{
+    struct test_objs tobjs;
+    struct lsquic_stream *stream;
+    struct stream_frame *frame;
+    const unsigned char empty_headers_frame[2] = {
+        0x01,   /* HEADERS frame type */
+        0x00,   /* Invalid zero-length payload */
+    };
+    unsigned char buf[1];
+    ssize_t nr;
+    int s;
+
+    init_test_objs(&tobjs, 0x1000, 0x1000, SCF_IETF);
+
+    stream = new_stream(&tobjs, 0, 0x1000);
+    frame = new_frame_in(&tobjs, 0, sizeof(empty_headers_frame), 0);
+    memcpy((unsigned char *) frame->data_frame.df_data, empty_headers_frame,
+                                                        sizeof(empty_headers_frame));
+    s = lsquic_stream_frame_in(stream, frame);
+    assert(0 == s);
+
+    assert(lsquic_stream_readable(stream));
+    nr = lsquic_stream_read(stream, buf, sizeof(buf));
+    assert(-1 == nr);
+    assert(EBADMSG == errno);
+
+    lsquic_stream_destroy(stream);
+    deinit_test_objs(&tobjs);
+}
+
+
 int
 main (int argc, char **argv)
 {
@@ -892,6 +924,7 @@ main (int argc, char **argv)
     test_multiple_hsets_fifo(1);
     test_gquic_hset_limit();
     test_read_headers_http1x();
+    test_hq_filter_error_is_readable();
 
     return 0;
 }


### PR DESCRIPTION
- [FIX, SPEC] Require 3 uni streams for HTTP/3 connections
- [FIX] Abort connection when STOP_SENDING comes in for a critical stream
- [FIX] Fix unreadable HQ filter error state
- [FIX] Reset errno before parsing content length
- [FIX] Use ls-qpack 2.6.6 to pick up latest fix
- [FIX] Abort if QDEC handler cannot write to fral-backed stream