### PR TITLE
Release 4.9.3

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+2026-07-31
+    - 4.9.3
+    - [FIX] Cancel failed QPACK header transactions
+    - Update to ls-qpack 2.7.0 to allow all header cancellations
+    - [FIX] MinGW compatibility (#670)
+    - [FIX] Preserve HTTP header errors in QPACK decode handler
+
 2026-07-26
     - 4.9.2
     - [FIX, SPEC] Require 3 uni streams for HTTP/3 connections

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = u'LiteSpeed Technologies'
 # The short X.Y version
 version = u'4.9'
 # The full version, including alpha/beta/rc tags
-release = u'4.9.2'
+release = u'4.9.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #define LSQUIC_MAJOR_VERSION 4
 #define LSQUIC_MINOR_VERSION 9
-#define LSQUIC_PATCH_VERSION 2
+#define LSQUIC_PATCH_VERSION 3
 
 #define LSQUIC_QUOTE(x)     #x
 #define LSQUIC_SVAL(v)      LSQUIC_QUOTE(v)

--- a/src/liblsquic/lsquic_qdec_hdl.c
+++ b/src/liblsquic/lsquic_qdec_hdl.c
@@ -363,6 +363,17 @@ qdh_in_on_new (void *stream_if_ctx, struct lsquic_stream *stream)
 }
 
 
+#define QDH_ABORT_CONN_ONCE(qdh_, ...) do                                   \
+{                                                                           \
+    if (!((qdh_)->qdh_flags & QDH_CONN_ABORTED))                            \
+    {                                                                       \
+        (qdh_)->qdh_flags |= QDH_CONN_ABORTED;                              \
+        (qdh_)->qdh_conn->cn_if->ci_abort_error((qdh_)->qdh_conn,           \
+                                                            __VA_ARGS__);   \
+    }                                                                       \
+} while (0)
+
+
 static size_t
 qdh_read_encoder_stream (void *ctx, const unsigned char *buf, size_t sz,
                                                                     int fin)
@@ -374,7 +385,7 @@ qdh_read_encoder_stream (void *ctx, const unsigned char *buf, size_t sz,
     if (fin)
     {
         LSQ_INFO("encoder stream is closed");
-        qdh->qdh_conn->cn_if->ci_abort_error(qdh->qdh_conn, 1,
+        QDH_ABORT_CONN_ONCE(qdh, 1,
             HEC_CLOSED_CRITICAL_STREAM, "Peer closed QPACK encoder stream");
         goto end;
     }
@@ -384,7 +395,7 @@ qdh_read_encoder_stream (void *ctx, const unsigned char *buf, size_t sz,
     {
         LSQ_INFO("error reading encoder stream");
         qerr = lsqpack_dec_get_err_info(&qdh->qdh_decoder);
-        qdh->qdh_conn->cn_if->ci_abort_error(qdh->qdh_conn, 1,
+        QDH_ABORT_CONN_ONCE(qdh, 1,
             HEC_QPACK_ENCODER_STREAM_ERROR, "Error interpreting QPACK encoder "
             "stream; offset %"PRIu64", line %d", qerr->off, qerr->line);
         goto end;
@@ -417,7 +428,7 @@ qdh_in_on_read (struct lsquic_stream *stream, lsquic_stream_ctx_t *ctx)
         else
         {
             LSQ_INFO("encoder stream closed by peer: abort connection");
-            qdh->qdh_conn->cn_if->ci_abort_error(qdh->qdh_conn, 1,
+            QDH_ABORT_CONN_ONCE(qdh, 1,
                 HEC_CLOSED_CRITICAL_STREAM, "encoder stream closed");
         }
         lsquic_stream_wantread(stream, 0);
@@ -571,9 +582,8 @@ qdh_hsi_process_wrapper (struct qpack_dec_hdl *qdh, void *hset,
 
     retval = qdh->qdh_enpub->enp_hsi_if->hsi_process_header(hset, xhdr);
     if (0 != retval)
-        qdh->qdh_conn->cn_if->ci_abort_error(qdh->qdh_conn, 1,
-            HEC_MESSAGE_ERROR,
-            "error processing headers");
+        QDH_ABORT_CONN_ONCE(qdh, 1, HEC_MESSAGE_ERROR,
+                                            "error processing headers");
 
     return retval;
 }
@@ -593,7 +603,7 @@ qdh_process_header (void *stream_p, struct lsxpack_header *xhdr)
                                                             xhdr->val_len);
         if (u->ctx.cont_len.has < 0)
         {
-            qdh->qdh_conn->cn_if->ci_abort_error(qdh->qdh_conn, 1,
+            QDH_ABORT_CONN_ONCE(qdh, 1,
                 HEC_MESSAGE_ERROR, "invalid or ambiguous content-length");
             return 1;
         }
@@ -719,7 +729,7 @@ qdh_header_read_results (struct qpack_dec_hdl *qdh,
     {
         qdh_maybe_destroy_hblock_ctx(qdh, stream);
         qerr = lsqpack_dec_get_err_info(&qdh->qdh_decoder);
-        qdh->qdh_conn->cn_if->ci_abort_error(qdh->qdh_conn, 1,
+        QDH_ABORT_CONN_ONCE(qdh, 1,
             HEC_QPACK_DECOMPRESSION_FAILED, "QPACK decompression error; "
             "stream %"PRIu64", offset %"PRIu64", line %d", qerr->stream_id,
             qerr->off, qerr->line);

--- a/src/liblsquic/lsquic_qdec_hdl.h
+++ b/src/liblsquic/lsquic_qdec_hdl.h
@@ -22,7 +22,7 @@ struct qpack_dec_hdl
     struct lsquic_conn      *qdh_conn;
     enum {
         QDH_INITIALIZED     = 1 << 0,
-        QDH_PUSH_PROMISE    = 1 << 1,
+        QDH_CONN_ABORTED    = 1 << 1,
         QDH_SAVE_UA         = 1 << 2,
         QDH_SERVER          = 1 << 3,
     }                        qdh_flags;

--- a/src/liblsquic/lsquic_qenc_hdl.c
+++ b/src/liblsquic/lsquic_qenc_hdl.c
@@ -377,7 +377,7 @@ qeh_write_headers (struct qpack_enc_hdl *qeh, lsquic_stream_id_t stream_id,
     size_t enc_sz, hea_sz, total_enc_sz;
     ssize_t nw;
     enum lsqpack_enc_status st;
-    int i, s, write_to_stream;
+    int i, s, write_to_stream, header_started;
     enum lsqpack_enc_flags enc_flags;
     enum qwh_status retval;
 #ifndef WIN32
@@ -389,6 +389,7 @@ qeh_write_headers (struct qpack_enc_hdl *qeh, lsquic_stream_id_t stream_id,
         return QWH_ERR;
 #endif
 
+    header_started = 0;
     if (qeh->qeh_exp_rec)
     {
         const lsquic_time_t now = lsquic_time_now();
@@ -407,6 +408,7 @@ qeh_write_headers (struct qpack_enc_hdl *qeh, lsquic_stream_id_t stream_id,
         retval = QWH_ERR;
         goto end;
     }
+    header_started = 1;
     LSQ_DEBUG("begin encoding headers for stream %"PRIu64, stream_id);
 
     if (qeh->qeh_enc_sm_out)
@@ -489,6 +491,7 @@ qeh_write_headers (struct qpack_enc_hdl *qeh, lsquic_stream_id_t stream_id,
         retval = QWH_ERR;
         goto end;
     }
+    header_started = 0;
 
     if ((size_t) nw < *prefix_sz)
     {
@@ -520,6 +523,15 @@ qeh_write_headers (struct qpack_enc_hdl *qeh, lsquic_stream_id_t stream_id,
     }
 
   end:
+    if (header_started)
+    {
+        s = lsqpack_enc_cancel_header(&qeh->qeh_encoder);
+        if (s != 0)
+        {
+            LSQ_WARN("could not cancel header");
+            retval = QWH_ERR;
+        }
+    }
 #ifdef WIN32
     _freea(enc_buf);
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ SET(TESTS
     parse_packet_in
     purga
     push_disabled
+    qenc_hdl
     qlog
     quic_be_floats
     reg_pkt_headergen

--- a/tests/test_h3_framing.c
+++ b/tests/test_h3_framing.c
@@ -285,6 +285,8 @@ struct test_dec_hset
     unsigned              finalized;
 };
 
+static int s_test_hset_header_error;
+
 static int s_ack_written;
 
 static void
@@ -497,7 +499,11 @@ test_process_hset_header (void *hset_p, struct lsxpack_header *xhdr)
     struct test_dec_hset *const hset = hset_p;
 
     if (xhdr)
+    {
+        if (s_test_hset_header_error)
+            return 1;
         ++hset->count;
+    }
     else
         hset->finalized = 1;
 
@@ -2183,7 +2189,9 @@ expect_header_block_result (struct lsxpack_header *hdrs, unsigned count,
     if (expect_abort)
     {
         assert(lsquic_stream_readable(recv_stream));
-        assert(s_abort_error.count >= 1);
+        assert(s_abort_error.count == 1);
+        assert(s_abort_error.is_app == 1);
+        assert(s_abort_error.error_code == HEC_MESSAGE_ERROR);
 
         hset = lsquic_stream_get_hset(recv_stream);
         assert(hset == NULL);
@@ -2372,6 +2380,68 @@ test_content_length_overflow_is_rejected (void)
 }
 
 
+static void
+test_header_processing_error_stays_message_error (void)
+{
+    struct test_objs sender, receiver;
+    struct lsquic_stream *send_stream, *recv_stream;
+    struct stream_frame *frame;
+    size_t nw;
+    int fin, s;
+    unsigned char buf[0x1000];
+    struct lsxpack_header req_hdrs_arr[] = {
+        { XHDR(":method", "GET") },
+        { XHDR(":scheme", "https") },
+        { XHDR(":path", "/") },
+        { XHDR(":authority", "example.com") },
+    };
+    struct lsquic_http_headers req_hdrs = {
+        .count = sizeof(req_hdrs_arr) / sizeof(req_hdrs_arr[0]),
+        .headers = req_hdrs_arr,
+    };
+
+    init_test_ctl_settings(&g_ctl_settings);
+    g_ctl_settings.tcs_schedule_stream_packets_immediately = 1;
+
+    stream_ctor_flags |= SCF_IETF;
+
+    init_test_objs(&sender, 0x1000, 0x2000, 1252);
+    sender.ctor_flags |= SCF_HTTP|SCF_IETF;
+    send_stream = new_stream(&sender, 0, 0x1000);
+    s = lsquic_stream_send_headers(send_stream, &req_hdrs, 0);
+    assert(0 == s);
+    lsquic_stream_flush(send_stream);
+
+    nw = read_from_scheduled_packets(&sender.send_ctl, 0, buf, sizeof(buf),
+                                                                    0, &fin, 0);
+    assert(nw > 0);
+
+    init_test_objs(&receiver, 0x1000, 0x2000, 1252);
+    receiver.ctor_flags |= SCF_HTTP|SCF_IETF;
+    receiver.lconn.cn_flags |= LSCONN_SERVER;
+    use_test_hset_if(&receiver);
+    recv_stream = new_stream(&receiver, 0, 0x1000);
+
+    s_test_hset_header_error = 1;
+    frame = new_frame_in_ext(&receiver, 0, nw, fin, buf);
+    s = lsquic_stream_frame_in(recv_stream, frame);
+    assert(0 == s);
+
+    assert(lsquic_stream_readable(recv_stream));
+    assert(s_abort_error.count == 1);
+    assert(s_abort_error.is_app == 1);
+    assert(s_abort_error.error_code == HEC_MESSAGE_ERROR);
+    s_test_hset_header_error = 0;
+
+    lsquic_stream_destroy(recv_stream);
+    deinit_test_objs(&receiver);
+    lsquic_stream_destroy(send_stream);
+    deinit_test_objs(&sender);
+
+    stream_ctor_flags &= ~SCF_IETF;
+}
+
+
 int
 main (int argc, char **argv)
 {
@@ -2457,6 +2527,7 @@ main (int argc, char **argv)
             test_data_waits_for_hset_claim();
             test_content_length_max_value_ignores_stale_errno();
             test_content_length_overflow_is_rejected();
+            test_header_processing_error_stays_message_error();
             break;
         default:
             fprintf(stderr, "Unknown test subset: %d\n", test_subset);
@@ -2485,6 +2556,7 @@ main (int argc, char **argv)
         test_content_length_overrun_blocks_payload_delivery();
         test_content_length_max_value_ignores_stale_errno();
         test_content_length_overflow_is_rejected();
+        test_header_processing_error_stays_message_error();
     }
 
     return 0;

--- a/tests/test_qenc_hdl.c
+++ b/tests/test_qenc_hdl.c
@@ -1,0 +1,165 @@
+/* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
+/*
+ * test_qenc_hdl.c -- Test QPACK encoder stream handler
+ */
+
+#include <assert.h>
+#include <string.h>
+#include <sys/queue.h>
+
+#include "lsquic.h"
+#include "lsxpack_header.h"
+
+#include "lsquic_types.h"
+#include "lsquic_int_types.h"
+#include "lsquic_hash.h"
+#include "lsquic_conn.h"
+#include "lsquic_frab_list.h"
+#include "lsqpack.h"
+#include "lsquic_qenc_hdl.h"
+
+
+struct test_header
+{
+    struct lsxpack_header    th_xhdr;
+    char                     th_buf[0x100];
+};
+
+
+static void
+set_header (struct test_header *header, const char *name, const char *value)
+{
+    const size_t name_len = strlen(name);
+    const size_t value_len = strlen(value);
+
+    assert(name_len + value_len <= sizeof(header->th_buf));
+    memcpy(header->th_buf, name, name_len);
+    memcpy(header->th_buf + name_len, value, value_len);
+    lsxpack_header_set_offset2(&header->th_xhdr, header->th_buf, 0, name_len,
+                                                    name_len, value_len);
+}
+
+
+static void
+init_qeh (struct qpack_enc_hdl *qeh, struct lsquic_conn *conn,
+                                                        int dynamic_table)
+{
+    int s;
+
+    memset(qeh, 0, sizeof(*qeh));
+    LSCONN_INITIALIZE(conn);
+    lsquic_qeh_init(qeh, conn);
+    s = lsquic_qeh_settings(qeh, dynamic_table ? 0x1000 : 0,
+        dynamic_table ? 0x1000 : 0, dynamic_table ? 100 : 0, 0);
+    assert(0 == s);
+    if (dynamic_table)
+    {
+        /* Keep qeh_fral nonempty so that qeh_write_headers() buffers encoder
+         * instructions instead of dereferencing this placeholder stream.
+         */
+        s = lsquic_frab_list_write(&qeh->qeh_fral, "", 1);
+        assert(0 == s);
+        qeh->qeh_enc_sm_out = (void *) 1;
+    }
+}
+
+
+static enum qwh_status
+write_headers (struct qpack_enc_hdl *qeh,
+                const struct lsquic_http_headers *headers, size_t headers_sz)
+{
+    unsigned char buf[0x100];
+    size_t prefix_sz;
+    uint64_t completion_offset;
+    enum lsqpack_enc_header_flags hflags;
+
+    prefix_sz = lsquic_qeh_max_prefix_size(qeh);
+    assert(prefix_sz < sizeof(buf));
+    return lsquic_qeh_write_headers(qeh, 0, 0, headers, buf + prefix_sz,
+        &prefix_sz, &headers_sz, &completion_offset, &hflags);
+}
+
+
+static void
+assert_encoder_can_start_header (struct qpack_enc_hdl *qeh)
+{
+    int s;
+
+    s = lsqpack_enc_start_header(&qeh->qeh_encoder, 4, 0);
+    assert(0 == s);
+    s = lsqpack_enc_cancel_header(&qeh->qeh_encoder);
+    assert(0 == s);
+}
+
+
+static void
+test_cancel_on_header_output_exhaustion (void)
+{
+    struct qpack_enc_hdl qeh;
+    struct lsquic_conn conn;
+    struct test_header header;
+    struct lsquic_http_headers headers;
+    enum qwh_status status;
+
+    init_qeh(&qeh, &conn, 0);
+    set_header(&header, "x-test", "value");
+    headers = (struct lsquic_http_headers) {
+        .count = 1,
+        .headers = &header.th_xhdr,
+    };
+
+    status = write_headers(&qeh, &headers, 0);
+    assert(QWH_ENOBUF == status);
+    assert_encoder_can_start_header(&qeh);
+
+    lsquic_qeh_cleanup(&qeh);
+}
+
+
+static void
+test_cancel_dynamic_header_on_output_exhaustion (void)
+{
+    struct qpack_enc_hdl qeh;
+    struct lsquic_conn conn;
+    struct test_header header[3];
+    struct lsxpack_header xhdr[3];
+    struct lsquic_http_headers headers;
+    enum qwh_status status;
+    size_t fral_size;
+
+    init_qeh(&qeh, &conn, 1);
+    set_header(&header[0], ":method", "method");
+    set_header(&header[1], ":method", "method");
+    set_header(&header[2], "x-test",
+        "a-value-that-is-too-large-for-the-remaining-header-block-buffer");
+    xhdr[0] = header[0].th_xhdr;
+    xhdr[1] = header[1].th_xhdr;
+    xhdr[2] = header[2].th_xhdr;
+    headers = (struct lsquic_http_headers) {
+        .count = 3,
+        .headers = xhdr,
+    };
+
+    fral_size = lsquic_frab_list_size(&qeh.qeh_fral);
+    status = write_headers(&qeh, &headers, 32);
+    assert(QWH_ENOBUF == status);
+    assert(qeh.qeh_encoder.qpe_ins_count > 0);
+    assert(lsquic_frab_list_size(&qeh.qeh_fral) > fral_size);
+    assert_encoder_can_start_header(&qeh);
+
+    qeh.qeh_enc_sm_out = NULL;
+    lsquic_qeh_cleanup(&qeh);
+}
+
+
+int
+main (void)
+{
+    assert(0 == lsquic_global_init(LSQUIC_GLOBAL_CLIENT));
+
+    test_cancel_dynamic_header_on_output_exhaustion();
+    test_cancel_on_header_output_exhaustion();
+
+    lsquic_global_cleanup();
+    return 0;
+}


### PR DESCRIPTION
- [FIX] Cancel failed QPACK header transactions
- Update to ls-qpack 2.7.0 to allow all header cancellations
- [FIX] MinGW compatibility (#670)
- [FIX] Preserve HTTP header errors in QPACK decode handler