### PR TITLE
Write WebTransport stream flags to sm_bflags, not stream_flags

### DIFF
--- a/src/liblsquic/lsquic_stream.c
+++ b/src/liblsquic/lsquic_stream.c
@@ -4373,25 +4373,25 @@ lsquic_stream_conn (const lsquic_stream_t *stream)
 #if LSQUIC_WEBTRANSPORT_SERVER_SUPPORT
 void
 lsquic_stream_set_webtransport_session(lsquic_stream_t *s) {
-    s->stream_flags |= SMBF_WEBTRANSPORT_SESSION_STREAM;
+    s->sm_bflags |= SMBF_WEBTRANSPORT_SESSION_STREAM;
 }
 
 
 int
 lsquic_stream_is_webtransport_session(const lsquic_stream_t *s) {
-    return (s->stream_flags & SMBF_WEBTRANSPORT_SESSION_STREAM);
+    return (s->sm_bflags & SMBF_WEBTRANSPORT_SESSION_STREAM);
 }
 
 
 int
 lsquic_stream_is_webtransport_client_bidi_stream(const lsquic_stream_t *s) {
-    return (s->stream_flags & SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM);
+    return (s->sm_bflags & SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM);
 }
 
 
 int
 lsquic_stream_get_webtransport_session_stream_id(const lsquic_stream_t *s) {
-    if(s->stream_flags & SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM)
+    if(s->sm_bflags & SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM)
     {
         return s->webtransport_session_stream_id;
     }
@@ -4948,7 +4948,7 @@ hq_read (void *ctx, const unsigned char *buf, size_t sz, int fin)
                     // check webtransport_session_stream_id availability as well SMBF_WEBTRANSPORT_SESSION_STREAM
                     // flag for webtransport_session_stream_id stream in app code
                     stream->webtransport_session_stream_id = filter->hqfi_webtransport_session_id;
-                    stream->stream_flags |= SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM;
+                    stream->sm_bflags |= SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM;
                     // disable header processing as we will not have any headers for this stream anymore
                     stream->sm_bflags &= ~SMBF_USE_HEADERS;
                     filter->hqfi_type = HQFT_DATA;


### PR DESCRIPTION
Fixes #674.

`SMBF_WEBTRANSPORT_SESSION_STREAM` and `SMBF_WEBTRANSPORT_CLIENT_BIDI_STREAM` are defined in `enum stream_b_flags`, but all five accessor sites (four accessors at `lsquic_stream.c:4375`–`4399`, one setter in the HQ frame filter at `lsquic_stream.c:4951`) read and write `stream->stream_flags`. Bits 14 and 15 of `enum stream_flags` are `STREAM_HEAD_IN_FIN` and `STREAM_FRAMES_ELIDED`, so the mix-up corrupts unrelated stream state rather than merely misfiling the WebTransport bits — the issue has the full walk-through of the three failure modes:

- the session stream is marked FIN-reached as soon as its headers are read (`STREAM_HEAD_IN_FIN` collision), a premature end of the one stream that must stay open for the session's lifetime;
- resetting a client bidi stream skips `lsquic_send_ctl_elide_stream_frames()` for unacked frames (`STREAM_FRAMES_ELIDED` collision);
- any request stream whose incoming headers carried FIN answers yes to `lsquic_stream_is_webtransport_session()`.

The change is the minimal field swap at those five sites. We have been running it for a while as a vendored patch in Bun's HTTP/3 server (WebTransport datagrams over lsquic), where the session stream staying open past its headers is what the feature depends on.

I'm aware #629 replaces these accessors outright; this is the small fix for master/4.9.x in the meantime.
