### PR TITLE
Fix explicit IETF connection close notification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,18 @@ HTTP/non-HTTP, and mini/full connections.
   current task.
 - Do not commit generated build files or test artifacts.
 
+## Commit messages
+
+- Keep summary and body lines to at most 72 characters.
+- For a bug fix, begin the summary with `Fix: `.
+- Follow the summary with a blank line and one or two human-readable,
+  ASCII-only paragraphs that describe what was fixed and why.  Describe
+  how only when it is not obvious from the code.
+- Use two spaces after a sentence-ending period when another sentence
+  follows on the same line.
+- When a commit fixes a GitHub issue, identify it in a final paragraph
+  using `Fixes #NNN.`.
+
 ## C style
 
 Follow the surrounding file and these project conventions:
@@ -81,6 +93,9 @@ Follow the surrounding file and these project conventions:
 - Use snake_case.  Non-static functions begin with `lsquic_`.  Function names
   normally consist of a module name followed by a verb; otherwise begin with
   a verb.  Do not begin static function names with an underscore.
+- Prefix a function with `maybe_` when it checks whether the requested action
+  is applicable and may return without performing it.  Reserve an unqualified
+  action name for a function that performs the action whenever it is called.
 - Prefix structure members with an abbreviation derived from the structure
   name, matching nearby members.
 - Outside the user-facing API, use `struct foo *` rather than `foo_t *` and do

--- a/bin/http_client.c
+++ b/bin/http_client.c
@@ -224,6 +224,7 @@ struct lsquic_conn_ctx {
                                              */
     enum {
         CH_SESSION_RESUME_SAVED   = 1 << 0,
+        CH_RECV_NO_ERROR_CLOSE    = 1 << 1,
     }                    ch_flags;
 };
 
@@ -340,6 +341,29 @@ create_another_conn_or_stop (evutil_socket_t sock, short events, void *ctx)
 }
 
 
+static int
+wait_for_close_mode (const struct http_client_ctx *client_ctx)
+{
+    return client_ctx->hcc_test_type
+        && 0 == strcasecmp(client_ctx->hcc_test_type, "wait-for-close");
+}
+
+
+static void
+http_client_on_conncloseframe_received (lsquic_conn_t *conn, int app_error,
+        uint64_t error_code, const char *UNUSED_reason, int UNUSED_reason_len)
+{
+    lsquic_conn_ctx_t *conn_h = lsquic_conn_get_ctx(conn);
+
+    if (wait_for_close_mode(conn_h->client_ctx)
+                                    && app_error == 0 && error_code == 0)
+    {
+        conn_h->ch_flags |= CH_RECV_NO_ERROR_CLOSE;
+        LSQ_NOTICE("TEST: received transport CONNECTION_CLOSE(NO_ERROR)");
+    }
+}
+
+
 static void
 http_client_on_conn_closed (lsquic_conn_t *conn)
 {
@@ -352,6 +376,13 @@ http_client_on_conn_closed (lsquic_conn_t *conn)
     status = lsquic_conn_status(conn, errmsg, sizeof(errmsg));
     LSQ_INFO("Connection closed.  Status: %d.  Message: %s", status,
         errmsg[0] ? errmsg : "<not set>");
+    if (wait_for_close_mode(conn_h->client_ctx)
+                            && !(conn_h->ch_flags & CH_RECV_NO_ERROR_CLOSE))
+    {
+        LSQ_ERROR("TEST: connection terminated without transport "
+                                        "CONNECTION_CLOSE(NO_ERROR)");
+        exit(EXIT_FAILURE);
+    }
     if (conn_h->client_ctx->hcc_flags & HCC_ABORT_ON_INCOMPLETE)
     {
         if (!(conn_h->client_ctx->hcc_flags & HCC_SEEN_FIN))
@@ -439,8 +470,6 @@ http_client_on_hsk_done (lsquic_conn_t *conn, enum lsquic_hsk_status status)
                 LSQ_NOTICE("TEST: calling lsquic_conn_going_away() on client connection");
                 lsquic_conn_going_away(conn);
             }
-            else
-                LSQ_WARN("unknown test type: %s", client_ctx->hcc_test_type);
         }
     }
     else
@@ -944,8 +973,13 @@ http_client_on_close (lsquic_stream_t *stream, lsquic_stream_ctx_t *st_h)
     --conn_h->ch_n_cc_streams;
     if (0 == conn_h->ch_n_reqs)
     {
-        LSQ_INFO("all requests completed, closing connection");
-        lsquic_conn_close(conn_h->conn);
+        if (wait_for_close_mode(client_ctx))
+            LSQ_INFO("all requests completed, waiting for peer close");
+        else
+        {
+            LSQ_INFO("all requests completed, closing connection");
+            lsquic_conn_close(conn_h->conn);
+        }
     }
     else
     {
@@ -972,6 +1006,7 @@ static struct lsquic_stream_if http_client_if = {
     .on_write               = http_client_on_write,
     .on_close               = http_client_on_close,
     .on_hsk_done            = http_client_on_hsk_done,
+    .on_conncloseframe_received = http_client_on_conncloseframe_received,
     .on_hset_in             = http_client_on_hset_in,
 };
 
@@ -1032,6 +1067,7 @@ static struct lsquic_stream_if hq_client_if = {
     .on_read                = hq_client_on_read,
     .on_write               = hq_client_on_write,
     .on_close               = http_client_on_close,
+    .on_conncloseframe_received = http_client_on_conncloseframe_received,
 };
 
 
@@ -1085,6 +1121,8 @@ usage (const char *prog)
 "   -Q ALPN     Use hq ALPN.  Specify, for example, \"h3-29\".\n"
 "   -J TEST     Run test. Available tests:\n"
 "                 goaway - call lsquic_conn_going_away() after handshake\n"
+"                 wait-for-close - keep the connection open after the last\n"
+"                    request and require CONNECTION_CLOSE(NO_ERROR) from peer\n"
             , prog);
 }
 
@@ -1706,6 +1744,12 @@ main (int argc, char **argv)
             ++s_discard_response;
             break;
         case 'J':
+            if (0 != strcasecmp(optarg, "goaway")
+                        && 0 != strcasecmp(optarg, "wait-for-close"))
+            {
+                LSQ_ERROR("unknown -J test: %s", optarg);
+                exit(EXIT_FAILURE);
+            }
             client_ctx.hcc_test_type = optarg;
             break;
         case 'u':   /* Accept p<U>sh promise */

--- a/bin/http_server.c
+++ b/bin/http_server.c
@@ -295,6 +295,13 @@ struct lsquic_conn_ctx;
 static void interop_server_hset_destroy (void *);
 
 
+enum server_test_mode {
+    SERVER_TEST_NONE,
+    SERVER_TEST_CLOSE,
+    SERVER_TEST_ABORT,
+};
+
+
 struct server_ctx {
     struct lsquic_conn_ctx  *conn_h;
     lsquic_engine_t             *engine;
@@ -307,15 +314,66 @@ struct server_ctx {
     unsigned                     n_current_conns;
     unsigned                     delay_resp_sec;
     uint64_t                     max_pacing_rate;
+    enum server_test_mode        test_mode;
 };
 
 struct lsquic_conn_ctx {
     lsquic_conn_t       *conn;
     struct server_ctx   *server_ctx;
+    struct event        *close_event;
     enum {
         RECEIVED_GOAWAY = 1 << 0,
+        TEST_CLOSE_SCHEDULED = 1 << 1,
     }                    flags;
 };
+
+
+static void
+close_conn (evutil_socket_t UNUSED_fd, short UNUSED_events, void *arg)
+{
+    struct lsquic_conn_ctx *conn_h = arg;
+    struct server_ctx *server_ctx = conn_h->server_ctx;
+
+    event_del(conn_h->close_event);
+    event_free(conn_h->close_event);
+    conn_h->close_event = NULL;
+
+    LSQ_NOTICE("TEST: calling lsquic_conn_%s()",
+        server_ctx->test_mode == SERVER_TEST_ABORT ? "abort" : "close");
+    if (server_ctx->test_mode == SERVER_TEST_ABORT)
+        lsquic_conn_abort(conn_h->conn);
+    else
+        lsquic_conn_close(conn_h->conn);
+    prog_process_conns(server_ctx->prog);
+}
+
+
+static void
+maybe_schedule_test_close (lsquic_stream_t *stream)
+{
+    lsquic_conn_ctx_t *conn_h;
+    struct server_ctx *server_ctx;
+    const struct timeval delay = { .tv_sec = 1, };
+
+    conn_h = lsquic_conn_get_ctx(lsquic_stream_conn(stream));
+    server_ctx = conn_h->server_ctx;
+    if (server_ctx->test_mode == SERVER_TEST_NONE
+            || lsquic_stream_is_pushed(stream)
+            || (conn_h->flags & TEST_CLOSE_SCHEDULED))
+        return;
+
+    conn_h->close_event = evtimer_new(prog_eb(server_ctx->prog), close_conn,
+                                                                    conn_h);
+    if (!conn_h->close_event
+                        || event_add(conn_h->close_event, &delay) != 0)
+    {
+        LSQ_ERROR("cannot schedule test connection close");
+        exit(EXIT_FAILURE);
+    }
+    conn_h->flags |= TEST_CLOSE_SCHEDULED;
+    LSQ_NOTICE("TEST: scheduled lsquic_conn_%s() in one second",
+        server_ctx->test_mode == SERVER_TEST_ABORT ? "abort" : "close");
+}
 
 
 static lsquic_conn_ctx_t *
@@ -343,7 +401,12 @@ http_server_on_new_conn (void *stream_if_ctx, lsquic_conn_t *conn)
         }
     }
 
-    lsquic_conn_ctx_t *conn_h = malloc(sizeof(*conn_h));
+    lsquic_conn_ctx_t *conn_h = calloc(1, sizeof(*conn_h));
+    if (!conn_h)
+    {
+        LSQ_ERROR("cannot allocate connection context");
+        exit(EXIT_FAILURE);
+    }
     conn_h->conn = conn;
     conn_h->server_ctx = server_ctx;
     server_ctx->conn_h = conn_h;
@@ -367,6 +430,12 @@ http_server_on_conn_closed (lsquic_conn_t *conn)
     static int stopped;
     lsquic_conn_ctx_t *conn_h = lsquic_conn_get_ctx(conn);
     LSQ_INFO("Connection closed");
+    if (conn_h->close_event)
+    {
+        event_del(conn_h->close_event);
+        event_free(conn_h->close_event);
+        conn_h->close_event = NULL;
+    }
     --conn_h->server_ctx->n_current_conns;
     if ((conn_h->server_ctx->prog->prog_flags & PROG_FLAG_COOLDOWN)
                                 && 0 == conn_h->server_ctx->n_current_conns)
@@ -1062,6 +1131,7 @@ http_server_on_read (struct lsquic_stream *stream, lsquic_stream_ctx_t *st_h)
 static void
 http_server_on_close (lsquic_stream_t *stream, lsquic_stream_ctx_t *st_h)
 {
+    maybe_schedule_test_close(stream);
     free(st_h->req_filename);
     free(st_h->req_path);
     if (st_h->reader.lsqr_ctx)
@@ -1800,6 +1870,9 @@ usage (const char *prog)
 "   -x RATE     Maximum pacing rate in bytes per second (throttle bandwidth)\n"
 "   -Y DELAY    Delay response for this many seconds -- use for debugging\n"
 "   -Q ALPN     Use hq mode; ALPN could be \"hq-29\", for example.\n"
+"   -J TEST     Run test after the first non-pushed request stream closes:\n"
+"                 close - call lsquic_conn_close() after one second\n"
+"                 abort - call lsquic_conn_abort() after one second\n"
             , prog);
 }
 
@@ -1968,7 +2041,7 @@ main (int argc, char **argv)
     prog_init(&prog, LSENG_SERVER|LSENG_HTTP, &server_ctx.sports,
                                             &http_server_if, &server_ctx);
 
-    while (-1 != (opt = getopt(argc, argv, PROG_OPTS "y:Y:n:p:r:w:P:x:h"
+    while (-1 != (opt = getopt(argc, argv, PROG_OPTS "y:Y:n:p:r:w:P:x:J:h"
 #if HAVE_OPEN_MEMSTREAM
                                                     "Q:"
 #endif
@@ -2013,6 +2086,17 @@ main (int argc, char **argv)
             break;
         case 'x':
             server_ctx.max_pacing_rate = strtoull(optarg, NULL, 10);
+            break;
+        case 'J':
+            if (0 == strcasecmp(optarg, "close"))
+                server_ctx.test_mode = SERVER_TEST_CLOSE;
+            else if (0 == strcasecmp(optarg, "abort"))
+                server_ctx.test_mode = SERVER_TEST_ABORT;
+            else
+            {
+                LSQ_ERROR("unknown -J test: %s", optarg);
+                exit(EXIT_FAILURE);
+            }
             break;
         case 'h':
             usage(argv[0]);

--- a/docs/apiref.rst
+++ b/docs/apiref.rst
@@ -1521,7 +1521,9 @@ Closing Connections
 .. function:: void lsquic_conn_close (lsquic_conn_t *conn)
 
     This closes the connection.  :member:`lsquic_stream_if.on_conn_closed`
-    and :member:`lsquic_stream_if.on_close` callbacks will be called.
+    and :member:`lsquic_stream_if.on_close` callbacks will be called.  Closing
+    an established IETF QUIC connection sends a transport-level
+    ``CONNECTION_CLOSE`` frame with the ``NO_ERROR`` code.
 
 .. function:: void lsquic_conn_abort (lsquic_conn_t *conn)
 

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -1632,7 +1632,8 @@ lsquic_conn_going_away (lsquic_conn_t *);
 
 /**
  * This forces connection close.  on_conn_closed and on_close callbacks
- * will be called.
+ * will be called.  Closing an established IETF QUIC connection sends a
+ * transport-level CONNECTION_CLOSE frame with the NO_ERROR code.
  */
 void
 lsquic_conn_close (lsquic_conn_t *);

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -145,7 +145,7 @@ enum ifull_conn_flags
 enum more_flags
 {
     MF_VALIDATE_PATH    = 1 << 0,
-    /* HOLE */                      /* <- Hole!  Reuse me! */
+    MF_USER_CLOSE       = 1 << 1,   /* User requested connection close */
     MF_CHECK_MTU_PROBE  = 1 << 2,
     MF_IGNORE_MISSING   = 1 << 3,
     MF_CONN_CLOSE_PACK  = 1 << 4,   /* CONNECTION_CLOSE has been packetized */
@@ -2948,6 +2948,7 @@ ietf_full_conn_ci_close (struct lsquic_conn *lconn)
     struct lsquic_hash_elem *el;
     enum stream_dir sd;
 
+    conn->ifc_mflags |= MF_USER_CLOSE;
     if (!(conn->ifc_flags & IFC_CLOSING))
     {
         for (el = lsquic_hash_first(conn->ifc_pub.all_streams); el;
@@ -8204,6 +8205,40 @@ ietf_full_conn_ci_user_stream_progress (struct lsquic_conn *lconn)
 }
 
 
+static int
+should_generate_connection_close (const struct ietf_full_conn *conn)
+{
+    if (conn->ifc_mflags & MF_CONN_CLOSE_PACK)
+        return 0;
+    /* Generate CONNECTION_CLOSE frame if:
+     *     ... user explicitly requested connection close;
+     */
+    else if (conn->ifc_mflags & MF_USER_CLOSE)
+        return 1;
+    /* or: this is a client and handshake was successful;
+     */
+    else if (!(conn->ifc_flags & (IFC_SERVER|IFC_HSK_FAILED)))
+        return 1;
+    /* or: sent a GOAWAY frame;
+     */
+    else if (conn->ifc_flags & IFC_GOAWAY_CLOSE)
+        return 1;
+    /* or: we received CONNECTION_CLOSE and we are not a server that chooses
+     * not to send CONNECTION_CLOSE responses.  From [RFC 9000, Section 10.2]:
+     " An endpoint that receives a CONNECTION_CLOSE frame MAY send a single
+     " packet containing a CONNECTION_CLOSE frame before entering the
+     " draining state
+     */
+    else if ((conn->ifc_flags & IFC_RECV_CLOSE)
+            && !((conn->ifc_flags & IFC_SERVER)
+                                    && conn->ifc_settings->es_silent_close))
+        return 1;
+    /* or: we have packets to send. */
+    else
+        return 0 != lsquic_send_ctl_n_scheduled(&conn->ifc_send_ctl);
+}
+
+
 static enum tick_st
 ietf_full_conn_ci_tick (struct lsquic_conn *lconn, lsquic_time_t now)
 {
@@ -8410,27 +8445,7 @@ ietf_full_conn_ci_tick (struct lsquic_conn *lconn, lsquic_time_t now)
         conn->ifc_flags |= IFC_TICK_CLOSE;
         if (conn->ifc_flags & IFC_RECV_CLOSE)
             tick |= TICK_CLOSE;
-        if (!(conn->ifc_mflags & MF_CONN_CLOSE_PACK)
-            /* Generate CONNECTION_CLOSE frame if:
-             *     ... this is a client and handshake was successful;
-             */
-            && (!(conn->ifc_flags & (IFC_SERVER|IFC_HSK_FAILED))
-                /* or: sent a GOAWAY frame;
-                 */
-                    || (conn->ifc_flags & IFC_GOAWAY_CLOSE)
-                /* or: we received CONNECTION_CLOSE and we are not a server
-                 * that chooses not to send CONNECTION_CLOSE responses.
-                 * From [draft-ietf-quic-transport-29]:
-                 " An endpoint that receives a CONNECTION_CLOSE frame MAY send
-                 " a single packet containing a CONNECTION_CLOSE frame before
-                 " entering the draining state
-                 */
-                    || ((conn->ifc_flags & IFC_RECV_CLOSE)
-                            && !((conn->ifc_flags & IFC_SERVER)
-                                    && conn->ifc_settings->es_silent_close))
-                /* or: we have packets to send. */
-                    || 0 != lsquic_send_ctl_n_scheduled(&conn->ifc_send_ctl))
-                )
+        if (should_generate_connection_close(conn))
         {
             /* CONNECTION_CLOSE frame should not be congestion controlled.
             RETURN_IF_OUT_OF_PACKETS(); */
@@ -9853,5 +9868,90 @@ lsquic_ietf_full_conn_test_stop_sending_critical (unsigned results[4])
 }
 
 
-typedef char dcid_elem_fits_in_128_bytes[sizeof(struct dcid_elem) <= 128 ? 1 : - 1];
+#ifndef NDEBUG
+void
+lsquic_ietf_full_conn_test_conn_close (unsigned results[13])
+{
+    enum {
+        IDLE_SERVER_USER_CLOSE,
+        IDLE_SERVER_USER_CLOSE_SILENT,
+        USER_CLOSE_MARKED,
+        USER_CLOSE_GENERATED_LATER,
+        CLIENT_CLOSE,
+        GOAWAY_CLOSE,
+        RECV_CLOSE,
+        RECV_CLOSE_SILENT,
+        SCHEDULED_PACKETS,
+        CLOSE_ALREADY_PACKETIZED,
+        IDLE_SERVER,
+        IDLE_SERVER_SILENT,
+        CLIENT_HSK_FAILED,
+    };
+    struct lsquic_engine_settings settings;
+    struct ietf_full_conn conn;
 
+    memset(&settings, 0, sizeof(settings));
+
+    memset(&conn, 0, sizeof(conn));
+    conn.ifc_flags = IFC_SERVER;
+    conn.ifc_mflags = MF_USER_CLOSE;
+    conn.ifc_settings = &settings;
+    results[IDLE_SERVER_USER_CLOSE] =
+                            should_generate_connection_close(&conn);
+    settings.es_silent_close = 1;
+    results[IDLE_SERVER_USER_CLOSE_SILENT] =
+                            should_generate_connection_close(&conn);
+
+    memset(&conn, 0, sizeof(conn));
+    conn.ifc_flags = IFC_SERVER|IFC_CLOSING;
+    conn.ifc_settings = &settings;
+    ietf_full_conn_ci_close(&conn.ifc_conn);
+    results[USER_CLOSE_MARKED] = !!(conn.ifc_mflags & MF_USER_CLOSE);
+    results[USER_CLOSE_GENERATED_LATER] =
+                            should_generate_connection_close(&conn);
+
+    memset(&conn, 0, sizeof(conn));
+    conn.ifc_settings = &settings;
+    results[CLIENT_CLOSE] = should_generate_connection_close(&conn);
+
+    memset(&conn, 0, sizeof(conn));
+    conn.ifc_flags = IFC_SERVER|IFC_GOAWAY_CLOSE;
+    conn.ifc_settings = &settings;
+    results[GOAWAY_CLOSE] = should_generate_connection_close(&conn);
+
+    memset(&conn, 0, sizeof(conn));
+    conn.ifc_flags = IFC_SERVER|IFC_RECV_CLOSE;
+    conn.ifc_settings = &settings;
+    settings.es_silent_close = 0;
+    results[RECV_CLOSE] = should_generate_connection_close(&conn);
+    settings.es_silent_close = 1;
+    results[RECV_CLOSE_SILENT] =
+                            should_generate_connection_close(&conn);
+
+    memset(&conn, 0, sizeof(conn));
+    conn.ifc_flags = IFC_SERVER;
+    conn.ifc_settings = &settings;
+    conn.ifc_send_ctl.sc_n_scheduled = 1;
+    results[SCHEDULED_PACKETS] = should_generate_connection_close(&conn);
+
+    conn.ifc_mflags = MF_USER_CLOSE|MF_CONN_CLOSE_PACK;
+    results[CLOSE_ALREADY_PACKETIZED] =
+                            should_generate_connection_close(&conn);
+
+    conn.ifc_mflags = 0;
+    conn.ifc_send_ctl.sc_n_scheduled = 0;
+    settings.es_silent_close = 0;
+    results[IDLE_SERVER] = should_generate_connection_close(&conn);
+    settings.es_silent_close = 1;
+    results[IDLE_SERVER_SILENT] =
+                            should_generate_connection_close(&conn);
+
+    memset(&conn, 0, sizeof(conn));
+    conn.ifc_flags = IFC_HSK_FAILED;
+    conn.ifc_settings = &settings;
+    results[CLIENT_HSK_FAILED] = should_generate_connection_close(&conn);
+}
+#endif
+
+
+typedef char dcid_elem_fits_in_128_bytes[sizeof(struct dcid_elem) <= 128 ? 1 : - 1];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ SET(TESTS
     blocked_gquic_be
     bw_sampler
     conn_close_gquic_be
+    conn_close_ietf
     crypto_gen
     cubic
     dec

--- a/tests/test_conn_close_ietf.c
+++ b/tests/test_conn_close_ietf.c
@@ -1,0 +1,50 @@
+/* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
+
+#include <assert.h>
+
+
+enum {
+    IDLE_SERVER_USER_CLOSE,
+    IDLE_SERVER_USER_CLOSE_SILENT,
+    USER_CLOSE_MARKED,
+    USER_CLOSE_GENERATED_LATER,
+    CLIENT_CLOSE,
+    GOAWAY_CLOSE,
+    RECV_CLOSE,
+    RECV_CLOSE_SILENT,
+    SCHEDULED_PACKETS,
+    CLOSE_ALREADY_PACKETIZED,
+    IDLE_SERVER,
+    IDLE_SERVER_SILENT,
+    CLIENT_HSK_FAILED,
+    N_RESULTS,
+};
+
+
+void
+lsquic_ietf_full_conn_test_conn_close (unsigned results[N_RESULTS]);
+
+
+int
+main (void)
+{
+    unsigned results[N_RESULTS];
+
+    lsquic_ietf_full_conn_test_conn_close(results);
+
+    assert(results[IDLE_SERVER_USER_CLOSE] == 1);
+    assert(results[IDLE_SERVER_USER_CLOSE_SILENT] == 1);
+    assert(results[USER_CLOSE_MARKED] == 1);
+    assert(results[USER_CLOSE_GENERATED_LATER] == 1);
+    assert(results[CLIENT_CLOSE] == 1);
+    assert(results[GOAWAY_CLOSE] == 1);
+    assert(results[RECV_CLOSE] == 1);
+    assert(results[RECV_CLOSE_SILENT] == 0);
+    assert(results[SCHEDULED_PACKETS] == 1);
+    assert(results[CLOSE_ALREADY_PACKETIZED] == 0);
+    assert(results[IDLE_SERVER] == 0);
+    assert(results[IDLE_SERVER_SILENT] == 0);
+    assert(results[CLIENT_HSK_FAILED] == 0);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- remember explicit user close requests until full IETF connections become closable
- emit transport CONNECTION_CLOSE(NO_ERROR) for explicit established closes while preserving idle-timeout, peer-close, and duplicate suppression behavior
- add focused regression coverage and HTTP client/server loopback test modes
- document the public close behavior and the maybe_ naming convention

Fixes #675.

## Testing

- Debug BoringSSL build
- ctest -R ^conn_close_ietf$ --output-on-failure
- full Debug CTest suite: 82/82 passed
- loopback smoke tests for server -J close and -J abort with client -J wait-for-close
- Release build; confirmed the debug-only internal test hook is absent
- Sphinx HTML build succeeded with existing warnings
- git diff --check