### PR TITLE
Release 4.9.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+2026-08-30
+    - 4.9.4
+    - [FIX] Notify peer on explicit IETF connection close (#675)
+    - [FIX] WebTransport flag corruption (#674)
+    - [FIX] Roll back header send state on stash failure.
+
 2026-07-31
     - 4.9.3
     - [FIX] Cancel failed QPACK header transactions

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -45,6 +45,7 @@ to the LiteSpeed QUIC and HTTP/3 Library:
     - youngseaz -- 32-bit transport param parser bug report
     - X1AOxiang -- Bug fixes
     - Alexey Mamontov -- Long-standing scheduled bytes underflow bug fix
+    - Amrit Kahlon -- Bug fixes
 
 Thank you!
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = u'LiteSpeed Technologies'
 # The short X.Y version
 version = u'4.9'
 # The full version, including alpha/beta/rc tags
-release = u'4.9.3'
+release = u'4.9.4'
 
 
 # -- General configuration ---------------------------------------------------

--- a/include/lsquic.h
+++ b/include/lsquic.h
@@ -27,7 +27,7 @@ extern "C" {
 
 #define LSQUIC_MAJOR_VERSION 4
 #define LSQUIC_MINOR_VERSION 9
-#define LSQUIC_PATCH_VERSION 3
+#define LSQUIC_PATCH_VERSION 4
 
 #define LSQUIC_QUOTE(x)     #x
 #define LSQUIC_SVAL(v)      LSQUIC_QUOTE(v)

--- a/src/liblsquic/lsquic_full_conn_ietf.c
+++ b/src/liblsquic/lsquic_full_conn_ietf.c
@@ -9951,7 +9951,10 @@ lsquic_ietf_full_conn_test_conn_close (unsigned results[13])
     conn.ifc_settings = &settings;
     results[CLIENT_HSK_FAILED] = should_generate_connection_close(&conn);
 }
+
+
 #endif
 
 
 typedef char dcid_elem_fits_in_128_bytes[sizeof(struct dcid_elem) <= 128 ? 1 : - 1];
+

--- a/src/liblsquic/lsquic_stream.c
+++ b/src/liblsquic/lsquic_stream.c
@@ -4098,12 +4098,15 @@ static int
 send_headers_ietf (struct lsquic_stream *stream,
                             const struct lsquic_http_headers *headers, int eos)
 {
+    struct stream_hq_frame *sfh = NULL;
     enum qwh_status qwh;
     const size_t max_prefix_size =
                     lsquic_qeh_max_prefix_size(stream->conn_pub->u.ietf.qeh);
     const size_t max_push_size = 1 /* Stream type */ + 8 /* Push ID */;
     size_t prefix_sz, headers_sz, hblock_sz, push_sz;
-    ssize_t nw;
+    ssize_t nw = 0;
+    const uint64_t tosend_off = stream->tosend_off;
+    const unsigned short n_buffered = stream->sm_n_buffered;
     unsigned char *header_block;
     enum lsqpack_enc_header_flags hflags;
     int rv;
@@ -4149,9 +4152,10 @@ send_headers_ietf (struct lsquic_stream *stream,
     /* Construct contiguous header block buffer including HQ framing */
     header_block = buf + max_push_size + max_prefix_size - prefix_sz - push_sz;
     hblock_sz = push_sz + prefix_sz + headers_sz;
-    if (!stream_activate_hq_frame(stream,
+    sfh = stream_activate_hq_frame(stream,
                 stream->sm_payload + stream->sm_n_buffered + push_sz,
-                HQFT_HEADERS, SHF_FIXED_SIZE, hblock_sz - push_sz))
+                HQFT_HEADERS, SHF_FIXED_SIZE, hblock_sz - push_sz);
+    if (!sfh)
         goto err;
 
     if (qwh == QWH_FULL)
@@ -4212,6 +4216,21 @@ send_headers_ietf (struct lsquic_stream *stream,
     return rv;
 
   err:
+    if (tosend_off == stream->tosend_off && n_buffered == stream->sm_n_buffered)
+    {
+        /* No bytes have been written: user can retry */
+        stream->sm_send_headers_state = SSHS_BEGIN;
+        if (sfh)
+            stream_hq_frame_put(stream, sfh);
+    }
+    else if (!(stream->sm_qflags & SMQF_ABORT_CONN))
+    {
+        /* The header block has been partially written.  It cannot be retried
+         * without corrupting the HTTP/3 stream, so reset the stream.
+         */
+        stream->sm_send_headers_state = SSHS_BEGIN;
+        stream_reset(stream, HEC_INTERNAL_ERROR, 1);
+    }
     rv = -1;
     goto clean;
 }

--- a/tests/test_conn_close_ietf.c
+++ b/tests/test_conn_close_ietf.c
@@ -1,5 +1,4 @@
 /* Copyright (c) 2017 - 2026 LiteSpeed Technologies Inc.  See LICENSE. */
-
 #include <assert.h>
 
 

--- a/tests/test_send_headers.c
+++ b/tests/test_send_headers.c
@@ -288,6 +288,7 @@ static struct test_vals {
     size_t              prefix_sz;
     size_t              headers_sz;
     uint64_t            completion_offset;
+    int                 skip_fill;
 } test_vals;
 
 
@@ -298,7 +299,8 @@ lsquic_qeh_write_headers (struct qpack_enc_hdl *qeh,
     size_t *prefix_sz, size_t *headers_sz, uint64_t *completion_offset,
     enum lsqpack_enc_header_flags *hflags)
 {
-    memset(buf - *prefix_sz, 0xC5, *prefix_sz + *headers_sz);
+    if (!test_vals.skip_fill)
+        memset(buf - *prefix_sz, 0xC5, *prefix_sz + *headers_sz);
     *prefix_sz = test_vals.prefix_sz;
     *headers_sz = test_vals.headers_sz;
     *completion_offset = test_vals.completion_offset;
@@ -491,6 +493,79 @@ test_partially_flushed_header_is_not_writeable (void)
 
     lsquic_stream_destroy(stream);
 
+    deinit_test_objs(&tobjs);
+}
+
+
+static void
+test_failed_header_stash_rolls_back_state (void)
+{
+    struct test_objs tobjs;
+    struct lsquic_stream *stream;
+    int s;
+
+    /* For our tests purposes, we treat headers as an opaque object */
+    struct lsquic_http_headers *headers = (void *) 1;
+
+    init_test_objs(&tobjs, 0x1000, 0x1000, SCF_IETF);
+
+    stream = new_stream(&tobjs, 0, 0x1000);
+    test_vals.status = QWH_PARTIAL;
+    test_vals.prefix_sz = 2;
+    test_vals.headers_sz = SIZE_MAX / 2;
+    test_vals.completion_offset = 10;
+    test_vals.skip_fill = 1;
+
+    s = lsquic_stream_send_headers(stream, headers, 0);
+    assert(-1 == s);
+    assert(SSHS_BEGIN == stream->sm_send_headers_state);
+    assert(NULL == stream->sm_header_block);
+    assert(STAILQ_EMPTY(&stream->sm_hq_frames));
+
+    test_vals.status = QWH_FULL;
+    test_vals.prefix_sz = 2;
+    test_vals.headers_sz = 40;
+    test_vals.completion_offset = 0;
+    test_vals.skip_fill = 0;
+
+    s = lsquic_stream_send_headers(stream, headers, 0);
+    assert(0 == s);
+
+    lsquic_stream_destroy(stream);
+    deinit_test_objs(&tobjs);
+}
+
+
+static void
+test_failed_partial_header_stash_resets_stream (void)
+{
+    struct test_objs tobjs;
+    struct lsquic_stream *stream;
+    const unsigned stream_window = 22;
+    int s;
+
+    /* For our tests purposes, we treat headers as an opaque object */
+    struct lsquic_http_headers *headers = (void *) 1;
+
+    init_test_objs(&tobjs, 0x1000, stream_window, SCF_IETF);
+
+    stream = new_stream(&tobjs, 0, stream_window);
+    test_vals.status = QWH_FULL;
+    test_vals.prefix_sz = 2;
+    test_vals.headers_sz = SIZE_MAX / 2 - 1024;
+    test_vals.completion_offset = 0;
+    test_vals.skip_fill = 1;
+
+    s = lsquic_stream_send_headers(stream, headers, 0);
+    assert(-1 == s);
+    assert(SSHS_BEGIN == stream->sm_send_headers_state);
+    assert(NULL == stream->sm_header_block);
+    assert(stream->sm_qflags & SMQF_SEND_RST);
+    assert(stream->stream_flags & STREAM_U_WRITE_DONE);
+    assert(HEC_INTERNAL_ERROR == stream->error_code);
+
+    test_vals.skip_fill = 0;
+    lsquic_stream_destroy(stream);
     deinit_test_objs(&tobjs);
 }
 
@@ -914,6 +989,8 @@ main (int argc, char **argv)
     test_flushes_and_closes();
     test_rejects_pending_header_overwrite();
     test_partially_flushed_header_is_not_writeable();
+    test_failed_header_stash_rolls_back_state();
+    test_failed_partial_header_stash_resets_stream();
     test_headers_wantwrite_restoration(0);
     test_headers_wantwrite_restoration(1);
     test_read_headers(0, 0);


### PR DESCRIPTION
- [FIX] Notify peer on explicit IETF connection close (#675)
- [FIX] WebTransport flag corruption (#674)
- [FIX] Roll back header send state on stash failure.