### PR TITLE
Add separate AppVeyor macOS build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Linux and MacOS build status](https://ci.appveyor.com/api/projects/status/x790ve5msewmva2b/branch/master?svg=true)](https://ci.appveyor.com/project/litespeedtech/lsquic-linux/branch/master)
+[![Linux build status](https://ci.appveyor.com/api/projects/status/x790ve5msewmva2b/branch/master?svg=true)](https://ci.appveyor.com/project/litespeedtech/lsquic-linux/branch/master)
+[![macOS build status](https://ci.appveyor.com/api/projects/status/qgnmk0gd1j2r5vah/branch/master?svg=true)](https://ci.appveyor.com/project/litespeedtech/lsquic-macos/branch/master)
 [![Windows build status](https://ci.appveyor.com/api/projects/status/ij4n3vy343pkgm1j/branch/master?svg=true)](https://ci.appveyor.com/project/litespeedtech/lsquic-windows/branch/master)
 [![FreeBSD build status](https://api.cirrus-ci.com/github/litespeedtech/lsquic.svg)](https://cirrus-ci.com/github/litespeedtech/lsquic)
 [![Documentation Status](https://readthedocs.org/projects/lsquic/badge/?version=latest)](https://lsquic.readthedocs.io/en/latest/?badge=latest)

--- a/appveyor-macos.yml
+++ b/appveyor-macos.yml
@@ -1,15 +1,15 @@
-version: 2.{branch}.{build}
+version: 1.{branch}.{build}
 
 skip_branch_with_pr: true
 
-image: Ubuntu2004
+image: MacOS
 
 build: off
 
 init:
 
 cache:
-# - boringssl -> appveyor-linux.yml # we define the commit in here
+# - boringssl -> appveyor-macos.yml # we define the commit in here
 
 install:
 


### PR DESCRIPTION
Split the existing AppVeyor Unix matrix into independent Linux and macOS projects.

- keep `appveyor-linux.yml` on Ubuntu 20.04 only
- add `appveyor-macos.yml` using the existing macOS image and build steps
- add an independent macOS status badge to README

The new AppVeyor project is: https://ci.appveyor.com/project/litespeedtech/lsquic-macos