### PR TITLE
Fix: handle memory allocation failure when appending SNI

### DIFF
--- a/src/liblsquic/lsquic_handshake.c
+++ b/src/liblsquic/lsquic_handshake.c
@@ -868,8 +868,11 @@ lsquic_enc_session_create_client (struct lsquic_conn *lconn, const char *domain,
     enc_session->enpub = enpub;
     enc_session->cid   = cid;
     enc_session->info  = info;
-    /* FIXME: allocation may fail */
-    lsquic_str_append(&enc_session->hs_ctx.sni, domain, strlen(domain));
+    if (0 != lsquic_str_append(&enc_session->hs_ctx.sni, domain, strlen(domain)))
+    {
+        lsquic_enc_session_destroy(enc_session);
+        return NULL;
+    }
     maybe_log_secrets(enc_session);
     if (lconn->cn_version >= LSQVER_050)
     {


### PR DESCRIPTION
### Problem
In `lsquic_enc_session_create_client()`, the return value of `lsquic_str_append()` when appending the SNI domain was not checked and had a `/* FIXME: allocation may fail */` comment. If dynamic memory reallocation fails under low-memory conditions, `hs_ctx.sni.str` remains unallocated while handshake processing continues.

### Fixes
- Check the return value of `lsquic_str_append()`.
- On allocation failure, call `lsquic_enc_session_destroy()` to release all associated resources and return `NULL`.
- Remove the resolved `/* FIXME */` comment.

### Potential
Prevents potential NULL-pointer dereference or undefined behavior during client handshake processing in out-of-memory (OOM) scenarios.