### PR TITLE
Fix: handle allocation failure for out_certs elements

### DIFF
--- a/src/liblsquic/lsquic_handshake.c
+++ b/src/liblsquic/lsquic_handshake.c
@@ -2775,7 +2775,7 @@ lsquic_enc_session_handle_chlo_reply (enc_session_t *enc_session_p,
 
     /* FIXME get the number first */
     lsquic_str_t **out_certs = NULL;
-    size_t out_certs_count = 0, i;
+    size_t out_certs_count = 0, i, j;
 
     ret = parse_hs(enc_session, data, len, &head_tag);
     if (ret)
@@ -2843,7 +2843,20 @@ lsquic_enc_session_handle_chlo_reply (enc_session_t *enc_session_p,
                 }
 
                 for (i=0; i<out_certs_count; ++i)
+                {
                     out_certs[i] = lsquic_str_new(NULL, 0);
+                    if (out_certs[i] == NULL)
+                    {
+                        for (j=0; j<i; ++j)
+                        {
+                            if(out_certs[j] != NULL)
+                                lsquic_str_delete(out_certs[j]);
+                        }
+                        free(out_certs);
+                        ret = -1;
+                        goto end;
+                    }
+                }
 
                 ret = handle_chlo_reply_verify_prof(enc_session, out_certs,
                                             &out_certs_count,


### PR DESCRIPTION
### Problem
In `lsquic_enc_session_handle_chlo_reply()`, when populating `out_certs`, the return value of `lsquic_str_new()` is not checked. If dynamic memory allocation fails, `out_certs[i]` remains `NULL`, leading to an immediate NULL-pointer dereference in subsequent functions like `handle_chlo_reply_verify_prof()`.

### Fixes
- Check the return value of `lsquic_str_new()`.
- On allocation failure:
  - Delete any previously allocated certificates (`lsquic_str_delete(out_certs[j])`).
  - Free the `out_certs` buffer itself (`free(out_certs)`).
  - Return `-1` to trigger session teardown.

### Potential
Prevents NULL-pointer dereference and memory leaks during CHLO reply processing under out-of-memory (OOM) conditions.